### PR TITLE
Main

### DIFF
--- a/sample_app/lorawan_aio/lorawan-broker/src/listen.py
+++ b/sample_app/lorawan_aio/lorawan-broker/src/listen.py
@@ -2,15 +2,21 @@
 import socket
 import paho.mqtt.client as paho
 import random
+import json
+from datetime import datetime
 
 # MQTT Configuration
 broker = "localhost"
 publishing_port = 1883
 topic = "LoRaWANGateway/Data"
+json_topic = "loradf"
 
 # UDP Server Configuration
 HOST = "0.0.0.0"  # Standard loopback interface address (localhost)
 PORT = 1700  # Port to listen on (non-privileged ports are > 1023)
+
+# Simulation Configuration
+gateway_ids = ["gateway_000A", "gateway_000B", "gateway_000C"]  # Example gateway IDs
 
 def on_publish(client, userdata, result):
     print("Data published")
@@ -29,6 +35,34 @@ def create_mqtt_client():
     client.on_publish = on_publish
     return client
 
+def generate_simulated_data():
+    """Generate realistic simulated values for LoRa metrics"""
+    return {
+        "timestamp": datetime.now().isoformat(),
+        "gateway_id": random.choice(gateway_ids),
+        "rssi": random.randint(-120, -40),  # Typical LoRa RSSI range
+        "snr": round(random.uniform(-20, 10), 1)  # Typical LoRa SNR range
+    }
+
+def format_json_payload(data):
+    try:
+        # Get simulated values
+        simulated_data = generate_simulated_data()
+        
+        # Create the JSON payload
+        payload = {
+            "raw_data": data.hex(),
+            "timestamp": simulated_data["timestamp"],
+            "gateway_id": simulated_data["gateway_id"],
+            "rssi": simulated_data["rssi"],
+            "snr": simulated_data["snr"]
+        }
+        
+        return json.dumps(payload)
+    except Exception as e:
+        print(f"Error formatting JSON: {e}")
+        return None
+
 def main():
     # Set up MQTT client
     client = create_mqtt_client()
@@ -44,7 +78,16 @@ def main():
             try:
                 data, addr = s.recvfrom(1024)
                 print(f"Received packet from {addr}")
+                
+                # Publish to original topic
                 client.publish(topic, data)
+                
+                # Format and publish JSON data
+                json_payload = format_json_payload(data)
+                if json_payload:
+                    client.publish(json_topic, json_payload)
+                    print(f"Published JSON payload: {json_payload}")
+                
             except Exception as e:
                 print(f"Error: {e}")
 

--- a/sample_app/lorawan_aio/lorawan-broker/src/listen.py
+++ b/sample_app/lorawan_aio/lorawan-broker/src/listen.py
@@ -1,28 +1,52 @@
 #!/usr/bin/python
-import socket, time
+import socket
 import paho.mqtt.client as paho
 import random
 
-broker="localhost"
-publishingport=1883
-def on_publish(client,userdata,result):             #create function for callback
-    print("data published")
-    print(result)
-    pass
+# MQTT Configuration
+broker = "localhost"
+publishing_port = 1883
+topic = "LoRaWANGateway/Data"
 
-client_id = f'python-mqtt-{random.randint(0, 1000)}'
-client1= paho.Client(paho.CallbackAPIVersion.VERSION1, client_id)                           #create client object
-client1.on_publish = on_publish                          #assign function to callback
-client1.connect(broker,publishingport)                                 #establish connection
-
+# UDP Server Configuration
 HOST = "0.0.0.0"  # Standard loopback interface address (localhost)
 PORT = 1700  # Port to listen on (non-privileged ports are > 1023)
 
-st = socket.socket(socket.AF_INET, socket.SOCK_DGRAM | socket.SO_REUSEADDR)
-st.bind((HOST, PORT))
+def on_publish(client, userdata, result):
+    print("Data published")
+    print(result)
 
-print("waiting on port", PORT)
-while 1:
-    data, addr = st.recvfrom(1024)
-    ret= client1.publish("LoRaWANGateway/Data", data) 
+def create_mqtt_client():
+    client_id = f'python-mqtt-{random.randint(0, 1000)}'
+    
+    # Check if CallbackAPIVersion is available (newer paho-mqtt versions)
+    if hasattr(paho, 'CallbackAPIVersion'):
+        client = paho.Client(paho.CallbackAPIVersion.VERSION1, client_id)
+    else:
+        # For older paho-mqtt versions
+        client = paho.Client(client_id)
+    
+    client.on_publish = on_publish
+    return client
 
+def main():
+    # Set up MQTT client
+    client = create_mqtt_client()
+    client.connect(broker, publishing_port)
+
+    # Set up UDP server
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind((HOST, PORT))
+        print(f"Waiting for UDP packets on port {PORT}")
+
+        while True:
+            try:
+                data, addr = s.recvfrom(1024)
+                print(f"Received packet from {addr}")
+                client.publish(topic, data)
+            except Exception as e:
+                print(f"Error: {e}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Enabled compatibility with latest versions of Paho:
# Check if CallbackAPIVersion is available (newer paho-mqtt versions)
    if hasattr(paho, 'CallbackAPIVersion'):
        client = paho.Client(paho.CallbackAPIVersion.VERSION1, client_id)
    else:
        # For older paho-mqtt versions
        client = paho.Client(client_id)
    