### PR TITLE
Removing OSM install from ACSA drops since it's no longer needed. 

### DIFF
--- a/script_automation/arc_edge_volumes_cloudsync_ubuntu_k3_single/README.md
+++ b/script_automation/arc_edge_volumes_cloudsync_ubuntu_k3_single/README.md
@@ -59,11 +59,6 @@ sudo sysctl -p
 az connectedk8s connect -n ${ARCNAME} -l ${REGION} -g ${RESOURCE_GROUP} --subscription ${SUBSCRIPTION}
 ```
 
-#### Install and Configure Open Service Mesh
-```bash
-az k8s-extension create --resource-group ${RESOURCE_GROUP} --cluster-name ${ARCNAME} --cluster-type connectedClusters --extension-type Microsoft.openservicemesh --scope cluster --name osm --config "osm.osm.featureFlags.enableWASMStats=false" --config "osm.osm.enablePermissiveTrafficPolicy=false" --config "osm.osm.configResyncInterval=10s" --config "osm.osm.osmController.resource.requests.cpu=100m" --config "osm.osm.osmBootstrap.resource.requests.cpu=100m" --config "osm.osm.injector.resource.requests.cpu=100m"
-```
-
 #### Install aio platform package for certificate management
 ```bash
 az k8s-extension create --cluster-name "${ARCNAME}" --name "${ARCNAME}-certmgr" --resource-group "${RESOURCE_GROUP}" --cluster-type connectedClusters --release-train preview --extension-type microsoft.iotoperations.platform --scope cluster --release-namespace cert-manager

--- a/script_automation/arc_edge_volumes_local_ubuntu_k3_single/README.md
+++ b/script_automation/arc_edge_volumes_local_ubuntu_k3_single/README.md
@@ -53,11 +53,6 @@ sudo sysctl -p
 az connectedk8s connect -n ${ARCNAME} -l ${REGION} -g ${RESOURCE_GROUP} --subscription ${SUBSCRIPTION}
 ```
 
-#### Install and Configure Open Service Mesh
-```bash
-az k8s-extension create --resource-group ${RESOURCE_GROUP} --cluster-name ${ARCNAME} --cluster-type connectedClusters --extension-type Microsoft.openservicemesh --scope cluster --name osm --config "osm.osm.featureFlags.enableWASMStats=false" --config "osm.osm.enablePermissiveTrafficPolicy=false" --config "osm.osm.configResyncInterval=10s" --config "osm.osm.osmController.resource.requests.cpu=100m" --config "osm.osm.osmBootstrap.resource.requests.cpu=100m" --config "osm.osm.injector.resource.requests.cpu=100m"
-```
-
 #### Install aio platform package for certificate management
 ```bash
 az k8s-extension create --cluster-name "${ARCNAME}" --name "${ARCNAME}-certmgr" --resource-group "${RESOURCE_GROUP}" --cluster-type connectedClusters --release-train preview --extension-type microsoft.iotoperations.platform --scope cluster --release-namespace cert-manager


### PR DESCRIPTION
Open Service Mesh is no longer required for TLS in Azure Container Storage Enabled by Azure Arc. 
Removing install from guide. 