### PR TITLE
new drop: monitor_arc_agent_logs.json

### DIFF
--- a/drops/monitor_arc_agent_logs.json
+++ b/drops/monitor_arc_agent_logs.json
@@ -1,0 +1,26 @@
+{
+    "Title": "Monitor Arc Agent Logs",
+    "Summary": "This solution centralizes azcmagent.log files from Azure Arc-enabled servers into Log Analytics, enabling streamlined troubleshooting and deeper insights—eliminating the need to access logs on individual machines.",
+    "Description": "This article introduces a streamlined approach to troubleshooting the Azure Arc Connected Machine Agent by centralizing azcmagent.log files from hybrid servers into a single Log Analytics Workspace. Instead of manually accessing logs on individual machines, users can now collect, transform, and analyze these logs centrally using Azure Monitor, Data Collection Rules, and custom tables. The guide walks through setting up the necessary Azure resources, configuring data collection, and applying KQL transformations to structure unstructured log data—enhancing observability and simplifying diagnostics across hybrid environments.",
+    "Cover": "https://github.com/Azure/arc_jumpstart_drops/blob/main/workbooks/arc_management_full/images/cover.jpg",
+    "Authors": [
+      {
+        "Name": "Tom Claes",
+        "Link": "https://www.linkedin.com/in/tomclaes-/"
+      }
+    ],
+    "Source": "https://github.com/claestom/azcmagent-logging-azuremonitor",
+    "Type": "tutorial_guide",
+    "Difficulty": "Medium",
+    "ProgrammingLanguage": [
+      "KQL"
+    ],
+    "Products": [
+      "Azure Arc-enabled Servers",
+      "Azure Monitor",
+      "Azure Arc"
+    ],
+    "LastModified": "2025-05-13T21:47:29.894Z",
+    "CreatedDate": "2025-05-13T21:51:29.894Z",
+    "Topics": []
+  }

--- a/drops/monitor_arc_agent_logs.json
+++ b/drops/monitor_arc_agent_logs.json
@@ -2,7 +2,7 @@
     "Title": "Monitor Arc Agent Logs",
     "Summary": "This solution centralizes azcmagent.log files from Azure Arc-enabled servers into Log Analytics, enabling streamlined troubleshooting and deeper insights—eliminating the need to access logs on individual machines.",
     "Description": "This article introduces a streamlined approach to troubleshooting the Azure Arc Connected Machine Agent by centralizing azcmagent.log files from hybrid servers into a single Log Analytics Workspace. Instead of manually accessing logs on individual machines, users can now collect, transform, and analyze these logs centrally using Azure Monitor, Data Collection Rules, and custom tables. The guide walks through setting up the necessary Azure resources, configuring data collection, and applying KQL transformations to structure unstructured log data—enhancing observability and simplifying diagnostics across hybrid environments.",
-    "Cover": "https://github.com/Azure/arc_jumpstart_drops/blob/main/workbooks/arc_management_full/images/cover.jpg",
+    "Cover": "",
     "Authors": [
       {
         "Name": "Tom Claes",

--- a/drops/monitor_arc_agent_logs.json
+++ b/drops/monitor_arc_agent_logs.json
@@ -1,7 +1,7 @@
 {
     "Title": "Monitor Arc Agent Logs",
     "Summary": "This solution centralizes azcmagent.log files from Azure Arc-enabled servers into Log Analytics, enabling streamlined troubleshooting and deeper insights—eliminating the need to access logs on individual machines.",
-    "Description": "This article introduces a streamlined approach to troubleshooting the Azure Arc Connected Machine Agent by centralizing azcmagent.log files from hybrid servers into a single Log Analytics Workspace. Instead of manually accessing logs on individual machines, users can now collect, transform, and analyze these logs centrally using Azure Monitor, Data Collection Rules, and custom tables. The guide walks through setting up the necessary Azure resources, configuring data collection, and applying KQL transformations to structure unstructured log data—enhancing observability and simplifying diagnostics across hybrid environments.",
+    "Description": "This drop introduces a streamlined approach to troubleshooting the Azure Arc Connected Machine Agent by centralizing azcmagent.log files from hybrid servers into a single Log Analytics Workspace. Instead of manually accessing logs on individual machines, users can now collect, transform, and analyze these logs centrally using Azure Monitor, Data Collection Rules, and custom tables. The guide walks through setting up the necessary Azure resources, configuring data collection, and applying KQL transformations to structure unstructured log data—enhancing observability and simplifying diagnostics across hybrid environments.",
     "Cover": "",
     "Authors": [
       {


### PR DESCRIPTION
This solution centralizes azcmagent.log files from Azure Arc-enabled servers into Log Analytics, enabling streamlined troubleshooting and deeper insights—eliminating the need to access logs on individual machines.

More information on the techcommunity article: [link to the article](https://techcommunity.microsoft.com/blog/azurearcblog/troubleshoot-the-azure-arc-agent-in-azure-using-azure-monitor--log-analytics-wor/4411895).