### PR TITLE
Add Drop: Azure Arc with AMPLS & Private Link (Update)

### DIFF
--- a/autogenerated/drops.json
+++ b/autogenerated/drops.json
@@ -1169,15 +1169,14 @@
     "Type": "script_automation",
     "Difficulty": "Medium",
     "ProgrammingLanguage": [
-      "Terraform",
-      "PowerShell"
+      "Terraform"
     ],
     "Products": [
       "Azure Arc",
       "Azure Monitor",
       "Azure Private Link"
     ],
-    "LastModified": "2025-07-04T10:00:00.000Z",
+    "LastModified": "2026-02-18T10:00:00.000Z",
     "CreatedDate": "2025-07-04T09:00:00.000Z",
     "Topics": [
       "Azure Arc",

--- a/drops/azure_arc_ampls_privatelink.json
+++ b/drops/azure_arc_ampls_privatelink.json
@@ -13,15 +13,14 @@
   "Type": "script_automation",
   "Difficulty": "Medium",
   "ProgrammingLanguage": [
-    "Terraform",
-    "PowerShell"
+    "Terraform"
   ],
   "Products": [
     "Azure Arc",
     "Azure Monitor",
     "Azure Private Link"
   ],
-  "LastModified": "2025-07-04T10:00:00.000Z",
+  "LastModified": "2026-02-18T10:00:00.000Z",
   "CreatedDate": "2025-07-04T09:00:00.000Z",
   "Topics": [
     "Azure Arc",


### PR DESCRIPTION
## Description
This PR adds a new Jumpstart Drop: **Azure Arc with AMPLS & Private Link**.

## What does this Drop do?
- Deploys a secure hybrid infrastructure using Azure Arc and Azure Monitor Private Link Scopes (AMPLS)
- Simulates an on-premises environment connected to Azure via VNet-to-VNet VPN Gateway
- Onboards a Windows Server VM to Azure Arc automatically via Custom Script Extension
- Routes all log and metrics traffic privately through AMPLS with Private DNS Zones
- Provides secure RDP access via Azure Bastion
- Fully automated with Terraform