### PR TITLE
Update Azure Arc Connectivity Check drop (ArcEndpointCheck.ps1 v2.6.0)

### DIFF
--- a/script_automation/arc_endpoint_check/ArcEndpointCheck.ps1
+++ b/script_automation/arc_endpoint_check/ArcEndpointCheck.ps1
@@ -136,6 +136,26 @@ $script:Stats     = [ordered]@{ OK = 0; Fail = 0; Warn = 0 }
 $script:LogBuffer = [System.Collections.ArrayList]::new()
 $script:Results   = [System.Collections.ArrayList]::new()
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function Test-IsValidProxyUri {
+    <#
+    .SYNOPSIS
+        Returns $true only when the input is a well-formed absolute http:// or
+        https:// URI. Rejects informational strings that azcmagent returns when
+        the proxy is not configured (e.g. "proxy.url has not been set").
+    #>
+    param([string]$Candidate)
+    if (-not $Candidate) { return $false }
+    $parsed = $null
+    return (
+        [System.Uri]::TryCreate($Candidate, [System.UriKind]::Absolute, [ref]$parsed) -and
+        $parsed.Scheme -in @('http', 'https')
+    )
+}
+
 function Add-Result {
     param(
         [Parameter(Mandatory)] [string]$Endpoint,
@@ -257,28 +277,32 @@ function Get-ProxyDiagnostics {
     # WinHTTP abaixo e apenas REPORTADO, nunca aplicado automaticamente.
     # Ref: https://learn.microsoft.com/azure/azure-arc/servers/manage-agent-proxy-settings
 
-    # 1) Parametro -ProxyUrl
+    # 1) Parametro -ProxyUrl (validado como URI absoluta http/https)
     if ($ProxyUrl) {
-        Write-Log "Proxy via parametro: $ProxyUrl" Info -NoCount
-        $script:EffectiveProxy = $ProxyUrl
+        if (Test-IsValidProxyUri -Candidate $ProxyUrl) {
+            Write-Log "Proxy via parametro: $ProxyUrl" Info -NoCount
+            $script:EffectiveProxy = $ProxyUrl
+        }
+        else {
+            Write-Log "Proxy via parametro INVALIDO (esperado http:// ou https://): $ProxyUrl" Warn
+        }
     }
 
     # WinHTTP (apenas informativo — o agente ignora o proxy system-wide)
-    #    Nota: o parse do 'netsh' abaixo depende de Windows em INGLES. Em SO
-    #    localizado (ex.: pt-BR) o regex pode nao casar e reportar 'Direct'
-    #    mesmo havendo proxy configurado no WinHTTP.
+    # Regex bilingue: EN "Proxy Server(s)" / pt-BR "Servidor(es) Proxy"
     try {
         $winhttp = netsh winhttp show proxy 2>$null
         $winhttpText = ($winhttp | Out-String).Trim()
-        if ($winhttpText -match 'Proxy Server\(s\)\s*:\s*(.+)') {
-            $winhttpProxy = $Matches[1].Trim()
+        if ($winhttpText -match 'Proxy Server\(s\)\s*:\s*(.+)|Servidor\(es\) Proxy\s*:\s*(.+)') {
+            $winhttpProxy = ($Matches[1], $Matches[2] | Where-Object { $_ } | Select-Object -First 1).Trim()
             Write-Log "WinHTTP Proxy: $winhttpProxy (informativo — o agente ignora o proxy system-wide)" Info -NoCount
         }
         else {
             Write-Log 'WinHTTP Proxy: Direct (sem proxy)' Info -NoCount
         }
-        if ($winhttpText -match 'Bypass List\s*:\s*(.+)') {
-            Write-Log "WinHTTP Bypass: $($Matches[1].Trim())" Info -NoCount
+        if ($winhttpText -match 'Bypass List\s*:\s*(.+)|Lista de bypass\s*:\s*(.+)') {
+            $bypassVal = ($Matches[1], $Matches[2] | Where-Object { $_ } | Select-Object -First 1).Trim()
+            Write-Log "WinHTTP Bypass: $bypassVal" Info -NoCount
         }
     }
     catch {
@@ -286,22 +310,35 @@ function Get-ProxyDiagnostics {
     }
 
     # 2) azcmagent config (proxy.url TEM PRECEDENCIA sobre HTTPS_PROXY)
+    #    IMPORTANTE: azcmagent retorna frases informativas quando o valor nao esta
+    #    configurado (ex.: "proxy.url has not been set"). Validamos com
+    #    Test-IsValidProxyUri para aceitar APENAS URIs http/https reais.
     $azcm = Get-AzcmagentPath
     if ($azcm) {
         try {
-            $proxyUrl = & $azcm config get proxy.url 2>$null
-            if ($proxyUrl -and $proxyUrl.Trim()) {
-                Write-Log "azcmagent proxy.url: $($proxyUrl.Trim())" Info -NoCount
+            $rawProxyUrl = & $azcm config get proxy.url 2>$null
+            $rawProxyUrlTrimmed = if ($rawProxyUrl) { ($rawProxyUrl | Out-String).Trim() } else { '' }
+
+            if (Test-IsValidProxyUri -Candidate $rawProxyUrlTrimmed) {
+                Write-Log "azcmagent proxy.url: $rawProxyUrlTrimmed" Info -NoCount
                 if (-not $script:EffectiveProxy) {
-                    $script:EffectiveProxy = $proxyUrl.Trim()
+                    $script:EffectiveProxy = $rawProxyUrlTrimmed
                 }
             }
             else {
-                Write-Log 'azcmagent proxy.url: (nao configurado)' Info -NoCount
+                # Mensagem informativa (ex.: "proxy.url has not been set")
+                if ($rawProxyUrlTrimmed) {
+                    Write-Log "azcmagent proxy.url: $rawProxyUrlTrimmed" Info -NoCount
+                }
+                else {
+                    Write-Log 'azcmagent proxy.url: (nao configurado)' Info -NoCount
+                }
             }
+
             $bypass = & $azcm config get proxy.bypass 2>$null
-            if ($bypass -and $bypass.Trim()) {
-                Write-Log "azcmagent proxy.bypass: $($bypass.Trim())" Info -NoCount
+            $bypassTrimmed = if ($bypass) { ($bypass | Out-String).Trim() } else { '' }
+            if ($bypassTrimmed) {
+                Write-Log "azcmagent proxy.bypass: $bypassTrimmed" Info -NoCount
             }
         }
         catch {
@@ -319,7 +356,12 @@ function Get-ProxyDiagnostics {
     if ($envProxy) {
         Write-Log "Env HTTPS_PROXY: $envProxy" Info -NoCount
         if (-not $script:EffectiveProxy) {
-            $script:EffectiveProxy = $envProxy
+            if (Test-IsValidProxyUri -Candidate $envProxy) {
+                $script:EffectiveProxy = $envProxy
+            }
+            else {
+                Write-Log "Env HTTPS_PROXY INVALIDO (esperado http:// ou https://): $envProxy" Warn
+            }
         }
     }
     else {
@@ -511,11 +553,12 @@ if ($IncludeMDE) {
 }
 
 # WAC endpoints (opcional via -IncludeWAC)
+# Nota: 'pas.windows.net' ja consta em $coreEndpoints e o $endpointGroupMap
+# preserva a precedencia Core, evitando duplicacao no sumario.
 $wacEndpoints = @()
 if ($IncludeWAC) {
     $wacEndpoints = @(
         "$Region.service.waconazure.com"
-        'pas.windows.net'
     )
 }
 
@@ -626,6 +669,8 @@ foreach ($ep in $allEndpoints) {
     $ep = $ep.Trim()
     if (-not $ep) { continue }
 
+    Write-Verbose "Testando: $ep"
+
     [void]$script:LogBuffer.Add('-' * 60)
     $group = if ($endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] } else { 'Dyn' }
     Add-Result -Endpoint $ep -Group $group
@@ -714,9 +759,12 @@ $azcmPath = Get-AzcmagentPath
 if ($azcmPath -and $script:EffectiveProxy) {
     try {
         $bypassRaw = & $azcmPath config get proxy.bypass 2>$null
-        if ($bypassRaw -and $bypassRaw.Trim()) {
-            $bypassClean = $bypassRaw.Trim().Trim('[', ']')
-            $proxyBypassCategories = $bypassClean -split ',' | ForEach-Object { $_.Trim() }
+        $bypassRawStr = if ($bypassRaw) { ($bypassRaw | Out-String).Trim() } else { '' }
+        if ($bypassRawStr) {
+            $bypassClean = $bypassRawStr.Trim('[', ']')
+            $proxyBypassCategories = $bypassClean -split ',' |
+                ForEach-Object { $_.Trim() } |
+                Where-Object { $_ }
         }
     }
     catch { }
@@ -748,7 +796,9 @@ $httpBypassedEndpoints = [System.Collections.ArrayList]::new()
 foreach ($cat in $proxyBypassCategories) {
     if ($bypassCategoryEndpoints.ContainsKey($cat)) {
         foreach ($bep in $bypassCategoryEndpoints[$cat]) {
-            [void]$httpBypassedEndpoints.Add($bep)
+            if ($httpBypassedEndpoints -notcontains $bep) {
+                [void]$httpBypassedEndpoints.Add($bep)
+            }
         }
     }
 }
@@ -766,6 +816,7 @@ foreach ($ep in $httpProbeEndpoints) {
 
     [void]$script:LogBuffer.Add('-' * 60)
     Add-Result -Endpoint $ep
+
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     try {
         $resp = Invoke-WebRequestSafe -Uri "https://$ep" -TimeoutSec 10
@@ -776,7 +827,7 @@ foreach ($ep in $httpProbeEndpoints) {
         if ($existing4) { $existing4.HTTP = "OK ($($resp.StatusCode))" }
     }
     catch {
-        $sw.Stop()
+        if ($sw.IsRunning) { $sw.Stop() }
         $code = $null
         if ($_.Exception.Response) {
             try { $code = [int]$_.Exception.Response.StatusCode } catch { }
@@ -873,6 +924,9 @@ Write-Host ("Totais: OK={0}  Fail={1}  Warn={2}  Modo={3}  Regiao={4}" -f `
 if ($script:EffectiveProxy) {
     Write-Host "Proxy utilizado: $($script:EffectiveProxy)" -ForegroundColor DarkGray
 }
+else {
+    Write-Host 'Proxy utilizado: Direct (sem proxy)' -ForegroundColor DarkGray
+}
 
 # Append tabela ao arquivo de log
 $tableString = $tableObjects | Format-Table -AutoSize | Out-String
@@ -881,6 +935,12 @@ Add-Content -Path $LogFilePath -Value '=================== SUMARIO =============
 Add-Content -Path $LogFilePath -Value $tableString.TrimEnd()
 Add-Content -Path $LogFilePath -Value ("Totais: OK={0}  Fail={1}  Warn={2}  Modo={3}  Regiao={4}" -f `
         $script:Stats.OK, $script:Stats.Fail, $script:Stats.Warn, $Mode, $Region)
+if ($script:EffectiveProxy) {
+    Add-Content -Path $LogFilePath -Value "Proxy utilizado: $($script:EffectiveProxy)"
+}
+else {
+    Add-Content -Path $LogFilePath -Value 'Proxy utilizado: Direct (sem proxy)'
+}
 
 Write-Host "`nLog completo: $LogFilePath" -ForegroundColor Cyan
 exit ([int]($script:Stats.Fail -gt 0))

--- a/script_automation/arc_endpoint_check/ArcEndpointCheck.ps1
+++ b/script_automation/arc_endpoint_check/ArcEndpointCheck.ps1
@@ -1,173 +1,886 @@
-# Purpose: This script checks the connectivity and status of Azure endpoints, including both static and dynamic endpoints, 
-# and validates Azure Arc functionality. It performs DNS resolution, network connectivity, and HTTP request tests, 
-# logging the results for review.
+#Requires -Version 5.1
 
-# Disclaimer: This script is intended for use in environments where connectivity to Azure endpoints and Azure Arc services 
-# needs to be validated. It relies on internet access to fetch dynamic endpoints and assumes the presence of `azcmagent.exe` 
-# for Azure Arc checks. Results are logged to a specified file, and proper access control on logs is advised.
+<#
+.SYNOPSIS
+    Validates Azure Arc connectivity, DNS resolution, and endpoint reachability
+    (public or Azure Private Link).
 
-# Define the region
-$region = "brazilsouth"
+.DESCRIPTION
+    - Automatically detects whether the host uses Azure Arc public endpoints or an
+      Azure Arc Private Link Scope (PLS):
+        1) 'azcmagent show -j' - if it reports a privateLinkScope => Private
+        2) otherwise, resolves 'gbl.his.arc.azure.com' and classifies as Private
+           when the IP is RFC1918 (covers the "DNS-based" Private Link scenario)
+    - Tests DNS, TCP/443, and (for selected endpoints) HTTP.
+    - Runs 'azcmagent check' with the correct flag for the detected mode.
+    - Detects and displays the proxy configuration following the agent precedence
+      (azcmagent proxy.url > HTTPS_PROXY). The Windows system-wide proxy
+      (WinHTTP/WinINET) is shown for information only, because the agent ignores it.
+    - Supports environments with Azure Firewall Explicit Proxy.
 
-# Define the log file path
-$logFilePath = "C:\temp\Arclogfile.txt"
+.PARAMETER Region
+    Azure region (default: eastus2).
 
-# Ensure log file exists before clearing
-if (-Not (Test-Path $logFilePath)) {
-    New-Item -ItemType File -Path $logFilePath -Force | Out-Null
-} else {
-    Clear-Content -Path $logFilePath -ErrorAction SilentlyContinue
-}
+.PARAMETER Mode
+    Auto | Public | Private. Default: Auto.
 
-# Write start of the log
-"Script started at $(Get-Date)" | Out-File -FilePath $logFilePath -Append
+.PARAMETER ProxyUrl
+    HTTP/HTTPS proxy URL (e.g., http://10.0.1.4:8443). If omitted, the script
+    auto-detects using the same precedence as the Azure Arc agent: 1) azcmagent
+    proxy.url (agent config - takes precedence); 2) the HTTPS_PROXY environment
+    variable. The Windows system-wide proxy (WinHTTP/WinINET) is only reported,
+    never applied automatically - mirroring the agent.
+    Ref: https://learn.microsoft.com/azure/azure-arc/servers/manage-agent-proxy-settings
 
-# Define the list of static endpoints
-$staticEndpoints = @(
-    "login.windows.net", "login.microsoftonline.com", "pas.windows.net", # AAD
-    "management.azure.com", # ARM
-    "global.handler.control.monitor.azure.com", # AMA
-    "gbl.his.arc.azure.com", "agentserviceapi.guestconfiguration.azure.com", # Arc
-    "dataprocessingservice.$region.arcdataservices.com", "telemetry.$region.arcdataservices.com" # ArcData and Telemetry
+.PARAMETER LogFilePath
+    Log file path. Default: C:\temp\Arclogfile.txt.
+
+.PARAMETER IncludeSQL
+    Includes Azure Arc-enabled SQL Server endpoints: data processing service and
+    telemetry (*.arcdataservices.com), san-af (legacy), and graph.microsoft.com
+    (Microsoft Entra authentication). Aligned with the official Arc SQL connectivity
+    test (DPS => 200, telemetry => 401).
+
+.PARAMETER IncludeAMA
+    Includes Azure Monitor Agent (AMA) endpoints.
+
+.PARAMETER IncludeMDE
+    Includes Microsoft Defender for Endpoint endpoints.
+
+.PARAMETER IncludeWAC
+    Includes Windows Admin Center endpoints.
+
+.PARAMETER CheckIncludeAll
+    Makes 'azcmagent check' validate everything: adds '--extensions all' (endpoints
+    for all supported extensions) and '--include-all' (extended use cases, e.g.,
+    Windows Server pay-as-you-go). Useful before onboarding. Replaces the
+    '--extensions sql' that -IncludeSQL would add.
+
+.EXAMPLE
+    PS> .\ArcEndpointCheck.ps1
+    Auto-detects the mode (Public/Private) and uses the default region 'eastus2'.
+
+.EXAMPLE
+    PS> .\ArcEndpointCheck.ps1 -Region brazilsouth -IncludeSQL -IncludeAMA
+    Runs against brazilsouth including SQL and AMA endpoints.
+
+.EXAMPLE
+    PS> .\ArcEndpointCheck.ps1 -Region eastus2 -ProxyUrl http://10.0.1.4:8443
+    Forces an explicit proxy for all HTTP tests.
+
+.EXAMPLE
+    PS> .\ArcEndpointCheck.ps1 -Region westeurope -Mode Public
+    Forces Public mode on westeurope (useful to validate the internet endpoint
+    list when the host does not have the agent installed yet).
+
+.EXAMPLE
+    PS> .\ArcEndpointCheck.ps1 -Region brazilsouth -Mode Private -LogFilePath D:\logs\arc-pls.txt
+    Forces Private Link validation and writes the log to a custom path. Adds the
+    '--enable-pls-check' flag to 'azcmagent check'.
+
+.EXAMPLE
+    PS> .\ArcEndpointCheck.ps1 -Region southcentralus -Verbose -IncludeSQL -IncludeAMA -IncludeMDE -IncludeWAC
+    Runs with detailed verbose output and all endpoint groups.
+    Common regions: eastus, eastus2, westus2, westus3, centralus, northeurope,
+    westeurope, uksouth, francecentral, switzerlandnorth, southeastasia,
+    japaneast, australiaeast, brazilsouth, southafricanorth, uaenorth.
+
+.EXAMPLE
+    PS> .\ArcEndpointCheck.ps1 -Mode Private -CheckIncludeAll
+    Runs 'azcmagent check' with '--extensions all --include-all' (endpoints for all
+    extensions + extended use cases) in Private mode.
+
+.NOTES
+    Requires PowerShell 5.1+ on Windows (uses netsh, Resolve-DnsName, and azcmagent.exe).
+    azcmagent.exe is optional (only for the final check).
+    Exit code: 0 = all tests OK; 1 = at least one failure.
+    Endpoint lists aligned with the Connected Machine agent network requirements and
+    its extensions (AMA/SQL/MDE/WAC).
+
+.LINK
+    https://azurearcjumpstart.com
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Region = 'eastus2',
+
+    [ValidateSet('Auto', 'Public', 'Private')]
+    [string]$Mode = 'Auto',
+
+    [string]$ProxyUrl,
+
+    [string]$LogFilePath = 'C:\temp\Arclogfile.txt',
+
+    [switch]$IncludeSQL,
+    [switch]$IncludeAMA,
+    [switch]$IncludeMDE,
+    [switch]$IncludeWAC,
+
+    [switch]$CheckIncludeAll
 )
 
-# Fetch dynamic endpoints for the specified region
-try {
-    $logMessage = "Running: Invoke-WebRequest -Uri 'https://guestnotificationservice.azure.com/urls/allowlist?api-version=2020-01-01&location=$region'"
-    $logMessage | Out-File -FilePath $logFilePath -Append
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'   # acelera Invoke-WebRequest e Test-NetConnection
 
-    $response = Invoke-WebRequest -Uri "https://guestnotificationservice.azure.com/urls/allowlist?api-version=2020-01-01&location=$region" -ErrorAction Stop
-    $dynamicEndpoints = ($response.Content -replace '\[|\]|"|\\n','').Split(',')
-    "Dynamic endpoints fetched: $($dynamicEndpoints -join ', ')" | Out-File -FilePath $logFilePath -Append
-} catch {
-    "Error fetching dynamic endpoints: $_" | Out-File -FilePath $logFilePath -Append
-    $dynamicEndpoints = @()
+$logDir = Split-Path -Path $LogFilePath -Parent
+if ($logDir -and -not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+Set-Content -Path $LogFilePath -Value "Script started at $(Get-Date -Format o)" -Force
+
+$script:Stats     = [ordered]@{ OK = 0; Fail = 0; Warn = 0 }
+$script:LogBuffer = [System.Collections.ArrayList]::new()
+$script:Results   = [System.Collections.ArrayList]::new()
+
+function Add-Result {
+    param(
+        [Parameter(Mandatory)] [string]$Endpoint,
+        [string]$Group = 'Core',
+        [string]$IP    = '-',
+        [string]$Type  = '-',
+        [string]$DNS   = '-',
+        [string]$TCP   = '-',
+        [string]$HTTP  = '-',
+        [string]$Latency = '-'
+    )
+    # Check if endpoint already exists and update
+    $existing = $script:Results | Where-Object { $_.Endpoint -eq $Endpoint }
+    if ($existing) {
+        if ($IP      -ne '-') { $existing.IP      = $IP }
+        if ($Type    -ne '-') { $existing.Type    = $Type }
+        if ($DNS     -ne '-') { $existing.DNS     = $DNS }
+        if ($TCP     -ne '-') { $existing.TCP     = $TCP }
+        if ($HTTP    -ne '-') { $existing.HTTP    = $HTTP }
+        if ($Latency -ne '-') { $existing.Latency = $Latency }
+    }
+    else {
+        [void]$script:Results.Add([ordered]@{
+            Endpoint = $Endpoint
+            Group    = $Group
+            IP       = $IP
+            Type     = $Type
+            DNS      = $DNS
+            TCP      = $TCP
+            HTTP     = $HTTP
+            Latency  = $Latency
+        })
+    }
 }
 
-# Combine static and dynamic endpoints
-$allEndpoints = $staticEndpoints + $dynamicEndpoints
+function Write-Log {
+    param(
+        [Parameter(Mandatory)] [string]$Message,
+        [ValidateSet('Info', 'OK', 'Fail', 'Warn')] [string]$Level = 'Info',
+        [switch]$NoCount
+    )
+    $color = @{ Info = 'Gray'; OK = 'Green'; Fail = 'Red'; Warn = 'Yellow' }[$Level]
+    $line  = "[{0}] [{1,-4}] {2}" -f (Get-Date -Format HH:mm:ss), $Level.ToUpper(), $Message
+    Write-Host $line -ForegroundColor $color
+    [void]$script:LogBuffer.Add($line)
 
-# List of allowed endpoints for HTTP request
-$allowedEndpoints = @(
-    "login.windows.net",
-    "login.microsoftonline.com",
-    "dataprocessingservice.$region.arcdataservices.com",
-    "telemetry.$region.arcdataservices.com"
+    if (-not $NoCount) {
+        if ($Level -eq 'OK')   { $script:Stats.OK++ }
+        if ($Level -eq 'Fail') { $script:Stats.Fail++ }
+        if ($Level -eq 'Warn') { $script:Stats.Warn++ }
+    }
+}
+
+function Save-LogBuffer {
+    if ($script:LogBuffer.Count -gt 0) {
+        Add-Content -Path $LogFilePath -Value $script:LogBuffer
+        $script:LogBuffer.Clear()
+    }
+}
+
+function Test-TcpPort {
+    param(
+        [Parameter(Mandatory)] [string]$ComputerName,
+        [int]$Port = 443,
+        [int]$TimeoutMs = 5000
+    )
+    $client = [System.Net.Sockets.TcpClient]::new()
+    try {
+        $iar = $client.BeginConnect($ComputerName, $Port, $null, $null)
+        if ($iar.AsyncWaitHandle.WaitOne($TimeoutMs, $false) -and $client.Connected) {
+            $client.EndConnect($iar) | Out-Null
+            return $true
+        }
+        return $false
+    }
+    catch { return $false }
+    finally { $client.Close() }
+}
+
+function Invoke-WebRequestSafe {
+    param(
+        [Parameter(Mandatory)] [string]$Uri,
+        [int]$TimeoutSec = 10
+    )
+    $params = @{
+        Uri             = $Uri
+        Method          = 'Get'
+        UseBasicParsing = $true
+        TimeoutSec      = $TimeoutSec
+        ErrorAction     = 'Stop'
+    }
+    if ($script:EffectiveProxy) {
+        $params['Proxy'] = $script:EffectiveProxy
+        $params['ProxyUseDefaultCredentials'] = $true
+    }
+    elseif ($PSVersionTable.PSVersion.Major -ge 6) {
+        # PS 6+: espelha o agente, que IGNORA o proxy system-wide. Em PS 5.1 o
+        # mesmo efeito e obtido neutralizando o DefaultWebProxy do .NET no setup.
+        $params['NoProxy'] = $true
+    }
+    return Invoke-WebRequest @params
+}
+
+# ---------------------------------------------------------------------------
+# Detecao e exibicao de proxy
+# ---------------------------------------------------------------------------
+$script:EffectiveProxy = $null
+
+function Get-ProxyDiagnostics {
+    Write-Log '=== DIAGNOSTICO DE PROXY ===' Info -NoCount
+    [void]$script:LogBuffer.Add('')
+
+    # Precedencia do proxy efetivo (usado nos testes HTTP deste script) — espelha
+    # o comportamento do Azure Connected Machine agent no Windows:
+    #   1) -ProxyUrl            (override explicito do operador)
+    #   2) azcmagent proxy.url  (config do agente — TEM PRECEDENCIA sobre env vars)
+    #   3) HTTPS_PROXY (env)    (system-wide)
+    # O agente IGNORA o proxy system-wide do Windows (WinHTTP/WinINET); por isso o
+    # WinHTTP abaixo e apenas REPORTADO, nunca aplicado automaticamente.
+    # Ref: https://learn.microsoft.com/azure/azure-arc/servers/manage-agent-proxy-settings
+
+    # 1) Parametro -ProxyUrl
+    if ($ProxyUrl) {
+        Write-Log "Proxy via parametro: $ProxyUrl" Info -NoCount
+        $script:EffectiveProxy = $ProxyUrl
+    }
+
+    # WinHTTP (apenas informativo — o agente ignora o proxy system-wide)
+    #    Nota: o parse do 'netsh' abaixo depende de Windows em INGLES. Em SO
+    #    localizado (ex.: pt-BR) o regex pode nao casar e reportar 'Direct'
+    #    mesmo havendo proxy configurado no WinHTTP.
+    try {
+        $winhttp = netsh winhttp show proxy 2>$null
+        $winhttpText = ($winhttp | Out-String).Trim()
+        if ($winhttpText -match 'Proxy Server\(s\)\s*:\s*(.+)') {
+            $winhttpProxy = $Matches[1].Trim()
+            Write-Log "WinHTTP Proxy: $winhttpProxy (informativo — o agente ignora o proxy system-wide)" Info -NoCount
+        }
+        else {
+            Write-Log 'WinHTTP Proxy: Direct (sem proxy)' Info -NoCount
+        }
+        if ($winhttpText -match 'Bypass List\s*:\s*(.+)') {
+            Write-Log "WinHTTP Bypass: $($Matches[1].Trim())" Info -NoCount
+        }
+    }
+    catch {
+        Write-Log "WinHTTP: nao foi possivel consultar ($($_.Exception.Message))" Warn
+    }
+
+    # 2) azcmagent config (proxy.url TEM PRECEDENCIA sobre HTTPS_PROXY)
+    $azcm = Get-AzcmagentPath
+    if ($azcm) {
+        try {
+            $proxyUrl = & $azcm config get proxy.url 2>$null
+            if ($proxyUrl -and $proxyUrl.Trim()) {
+                Write-Log "azcmagent proxy.url: $($proxyUrl.Trim())" Info -NoCount
+                if (-not $script:EffectiveProxy) {
+                    $script:EffectiveProxy = $proxyUrl.Trim()
+                }
+            }
+            else {
+                Write-Log 'azcmagent proxy.url: (nao configurado)' Info -NoCount
+            }
+            $bypass = & $azcm config get proxy.bypass 2>$null
+            if ($bypass -and $bypass.Trim()) {
+                Write-Log "azcmagent proxy.bypass: $($bypass.Trim())" Info -NoCount
+            }
+        }
+        catch {
+            Write-Log "azcmagent config: falha ao consultar ($($_.Exception.Message))" Warn
+        }
+    }
+
+    # 3) Environment variables (verifica Machine -> Process -> User)
+    $envProxy = [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'Machine')
+    if (-not $envProxy) { $envProxy = [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'Process') }
+    if (-not $envProxy) { $envProxy = [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'User') }
+    $envNoProxy = [Environment]::GetEnvironmentVariable('NO_PROXY', 'Machine')
+    if (-not $envNoProxy) { $envNoProxy = [Environment]::GetEnvironmentVariable('NO_PROXY', 'Process') }
+    if (-not $envNoProxy) { $envNoProxy = [Environment]::GetEnvironmentVariable('NO_PROXY', 'User') }
+    if ($envProxy) {
+        Write-Log "Env HTTPS_PROXY: $envProxy" Info -NoCount
+        if (-not $script:EffectiveProxy) {
+            $script:EffectiveProxy = $envProxy
+        }
+    }
+    else {
+        Write-Log 'Env HTTPS_PROXY: (nao definido)' Info -NoCount
+    }
+    if ($envNoProxy) {
+        Write-Log "Env NO_PROXY: $envNoProxy" Info -NoCount
+    }
+
+    if ($script:EffectiveProxy) {
+        Write-Log "Proxy efetivo para testes HTTP: $($script:EffectiveProxy)" Info -NoCount
+    }
+    else {
+        Write-Log 'Proxy efetivo: Direct (sem proxy — testes HTTP vao direto, como o agente)' Info -NoCount
+    }
+
+    [void]$script:LogBuffer.Add('')
+}
+
+# ---------------------------------------------------------------------------
+# Deteccao automatica Public vs Private
+# ---------------------------------------------------------------------------
+function Get-AzcmagentPath {
+    $candidate = Join-Path $env:ProgramFiles 'AzureConnectedMachineAgent\azcmagent.exe'
+    if (Test-Path $candidate) { return $candidate }
+    return $null
+}
+
+function Test-IsPrivateIp {
+    param([string]$Ip)
+    if (-not $Ip) { return $false }
+    try {
+        $bytes = ([System.Net.IPAddress]::Parse($Ip)).GetAddressBytes()
+    }
+    catch { return $false }
+
+    # RFC1918 + 100.64/10 (CGNAT, comum em redes corporativas)
+    return ($bytes[0] -eq 10) -or
+           ($bytes[0] -eq 192 -and $bytes[1] -eq 168) -or
+           ($bytes[0] -eq 172 -and $bytes[1] -ge 16 -and $bytes[1] -le 31) -or
+           ($bytes[0] -eq 100 -and $bytes[1] -ge 64 -and $bytes[1] -le 127)
+}
+
+function Resolve-ArcMode {
+    Write-Log 'Detectando modo Arc (Public/Private)...' Info -NoCount
+
+    # 1) Via azcmagent show -j
+    $azcm = Get-AzcmagentPath
+    if ($azcm) {
+        try {
+            $json = & $azcm show -j 2>$null | ConvertFrom-Json
+            $pls = $json.privateLinkScope
+            if ($pls) {
+                Write-Log "azcmagent reporta privateLinkScope: $pls" Info -NoCount
+                return 'Private'
+            }
+            else {
+                # NAO conclui Public aqui: cai para o heuristico DNS abaixo. O
+                # Private Link pode ser "via DNS" (Private DNS Zones) sem o agente
+                # expor o PLS localmente em 'azcmagent show -j'.
+                Write-Log 'azcmagent nao reporta privateLinkScope; confirmando via DNS...' Info -NoCount
+            }
+        }
+        catch {
+            Write-Log "Falha ao consultar azcmagent show -j: $($_.Exception.Message). Caindo para fallback DNS." Warn
+        }
+    }
+    else {
+        Write-Log 'azcmagent.exe nao encontrado. Usando fallback DNS.' Warn
+    }
+
+    # 2) Fallback: resolver gbl.his.arc.azure.com
+    try {
+        $dns = Resolve-DnsName -Name 'gbl.his.arc.azure.com' -Type A -ErrorAction Stop
+        $ip  = ($dns | Where-Object IPAddress | Select-Object -First 1).IPAddress
+        if (Test-IsPrivateIp -Ip $ip) {
+            Write-Log "gbl.his.arc.azure.com resolve para IP privado ($ip) -> Private Link" Info -NoCount
+            return 'Private'
+        }
+        else {
+            Write-Log "gbl.his.arc.azure.com resolve para IP publico ($ip) -> Public" Info -NoCount
+            return 'Public'
+        }
+    }
+    catch {
+        Write-Log 'Nao foi possivel resolver gbl.his.arc.azure.com - assumindo Public.' Warn
+        return 'Public'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Detecao de modo e proxy
+# ---------------------------------------------------------------------------
+Get-ProxyDiagnostics
+
+# Alinhamento com o agente: o Azure Connected Machine agent IGNORA o proxy
+# system-wide do Windows (WinINET/WinHTTP). Se nenhum proxy efetivo foi
+# detectado, neutralizamos o DefaultWebProxy do .NET (PS 5.1) para que os
+# testes HTTP tambem vao direto. Em PS 6+ isso e feito via -NoProxy.
+if (-not $script:EffectiveProxy -and $PSVersionTable.PSVersion.Major -lt 6) {
+    try { [System.Net.WebRequest]::DefaultWebProxy = $null } catch { }
+}
+
+if ($Mode -eq 'Auto') {
+    $Mode = Resolve-ArcMode
+}
+Write-Log "Modo selecionado: $Mode | Regiao: $Region" Info -NoCount
+
+# Reset stats: fase de testes comeca aqui (detecao nao conta)
+$script:Stats.OK   = 0
+$script:Stats.Fail = 0
+$script:Stats.Warn = 0
+
+# ---------------------------------------------------------------------------
+# Endpoints — organizados por grupo funcional
+# ---------------------------------------------------------------------------
+
+# Endpoints que PODEM resolver para IP privado via Azure Private Link Scope.
+# Tudo que NAO esta nesta lista e sempre publico — nao gerar WARN em modo Private.
+$canBePrivateEndpoints = @(
+    'gbl.his.arc.azure.com'
+    'agentserviceapi.guestconfiguration.azure.com'
+    'dc.services.visualstudio.com'
+    'global.handler.control.monitor.azure.com'
 )
 
-# Filter the dynamic endpoints to match the allowed list
-$filteredDynamicEndpoints = $allowedEndpoints
+# Core Arc (obrigatorios) — alinhado a network-requirements do Connected Machine agent.
+# Doc: https://learn.microsoft.com/azure/azure-arc/servers/network-requirements
+$coreEndpoints = @(
+    # AAD / Identity (sempre; Public)
+    'login.windows.net'
+    'login.microsoftonline.com'
+    'pas.windows.net'
 
-# Combine static endpoints with the filtered dynamic endpoints for HTTP requests
-$finalEndpointsForRequest = $filteredDynamicEndpoints
+    # ARM (conexao/desconexao; Public salvo Resource Management Private Link)
+    'management.azure.com'
 
-# Iterate over all endpoints to test connectivity, DNS resolution, and HTTP response for the filtered dynamic endpoints
-foreach ($endpoint in $allEndpoints) {
-    $trimmedEndpoint = $endpoint.Trim()
+    # Arc HIMDS (sempre; Private via PLS)
+    'gbl.his.arc.azure.com'
 
-    # DNS resolution test
-    $dnsLogMessage = "Testing DNS resolution for: $($trimmedEndpoint)"
-    $dnsLogMessage | Out-File -FilePath $logFilePath -Append
+    # Guest Configuration / gestao de extensoes (sempre; Private via PLS)
+    'agentserviceapi.guestconfiguration.azure.com'
 
-    try {
-        $logMessage = "Running: Resolve-DnsName -Name $($trimmedEndpoint)"
-        $logMessage | Out-File -FilePath $logFilePath -Append
-        
-        $dnsResult = Resolve-DnsName -Name $trimmedEndpoint -ErrorAction Stop
-        $dnsOutput = "Success: DNS resolution succeeded for $($trimmedEndpoint): $($dnsResult.Name)"
-        Write-Host $dnsOutput -ForegroundColor Green
-        $dnsOutput | Out-File -FilePath $logFilePath -Append
-    } catch {
-        $dnsError = "Error: DNS resolution failed for $($trimmedEndpoint) - $_"
-        Write-Host $dnsError -ForegroundColor Red
-        $dnsError | Out-File -FilePath $logFilePath -Append
-    }
+    # Instalacao/atualizacao do agente (Public)
+    'packages.microsoft.com'
+    'download.microsoft.com'
 
-    # Connectivity test
-    $connectivityLogMessage = "Testing connectivity for: $($trimmedEndpoint)"
-    $connectivityLogMessage | Out-File -FilePath $logFilePath -Append
+    # Telemetria (opcional; NAO usado em agentes 1.24+; Public)
+    'dc.services.visualstudio.com'
+)
 
-    try {
-        $logMessage = "Running: Test-Connection -ComputerName $($trimmedEndpoint) -Count 1"
-        $logMessage | Out-File -FilePath $logFilePath -Append
-        
-        $pingResult = Test-Connection -ComputerName $trimmedEndpoint -Count 1 -ErrorAction Stop
-        $pingOutput = "Success: Connectivity succeeded for $($trimmedEndpoint): Response time: $($pingResult.ResponseTime)ms"
-        Write-Host $pingOutput -ForegroundColor Green
-        $pingOutput | Out-File -FilePath $logFilePath -Append
-    } catch {
-        $pingError = "Error: Connectivity test failed for $($trimmedEndpoint) - $_"
-        Write-Host $pingError -ForegroundColor Red
-        $pingError | Out-File -FilePath $logFilePath -Append
-    }
-
-    "----------------------------------------" | Out-File -FilePath $logFilePath -Append
+# SQL endpoints (opcional via -IncludeSQL) — Arc-enabled SQL Server.
+# Doc: network-requirements + sql/.../data-collection. Todos Public; TLS 1.2/1.3.
+$sqlEndpoints = @()
+if ($IncludeSQL) {
+    $sqlEndpoints = @(
+        # Data processing service + telemetria (extensoes a partir de mar/2024)
+        "dataprocessingservice.$Region.arcdataservices.com"
+        "telemetry.$Region.arcdataservices.com"
+        # Legado: usado por extensoes ate 13/fev/2024
+        "san-af-$Region-prod.azurewebsites.net"
+        # Autenticacao Microsoft Entra do Arc SQL (Public). So necessario se usar
+        # Entra auth; NAO e endpoint core do agente. Reachable direto, mas pode ser
+        # bloqueado em proxy split-tunnel -> apenas DNS/TCP (sem HTTP probe).
+        'graph.microsoft.com'
+    )
 }
 
-# HTTP request test (only for filtered dynamic endpoints)
-foreach ($endpoint in $finalEndpointsForRequest) {
-    $trimmedEndpoint = $endpoint.Trim()
+# AMA endpoints (opcional via -IncludeAMA) — Azure Monitor Agent.
+# Doc: azure-monitor-agent-network-configuration. Endpoints <workspace-id>.ods e
+# <dce>.ingest.monitor exigem IDs especificos -> nao testaveis genericamente.
+$amaEndpoints = @()
+if ($IncludeAMA) {
+    $amaEndpoints = @(
+        'global.handler.control.monitor.azure.com'   # control service
+        'global.prod.microsoftmetrics.com'           # metrics service
+        "$Region.handler.control.monitor.azure.com"  # DCRs da regiao
+        "$Region.monitoring.azure.com"               # custom metrics (opcional)
+    )
+}
 
-    # HTTP request test
-    $httpLogMessage = "Testing HTTP request for: $($trimmedEndpoint)"
-    $httpLogMessage | Out-File -FilePath $logFilePath -Append
+# MDE endpoints (opcional via -IncludeMDE)
+$mdeEndpoints = @()
+if ($IncludeMDE) {
+    $mdeEndpoints = @(
+        'unitedstates.x.cp.wd.microsoft.com'
+        'us-v20.events.data.microsoft.com'
+    )
+}
 
+# WAC endpoints (opcional via -IncludeWAC)
+$wacEndpoints = @()
+if ($IncludeWAC) {
+    $wacEndpoints = @(
+        "$Region.service.waconazure.com"
+        'pas.windows.net'
+    )
+}
+
+# Endpoints que respondem HTTP (validacao L7 — 200/400/401/403/404 = reachable).
+# NAO inclui graph.microsoft.com: e endpoint de Entra auth do Arc SQL (opcional) e
+# costuma ser bloqueado em proxy split-tunnel; o proprio teste oficial de
+# conectividade do Arc SQL valida apenas DPS + telemetria.
+$httpProbeEndpoints = @(
+    'login.windows.net'
+    'login.microsoftonline.com'
+    'management.azure.com'
+)
+if ($IncludeSQL) {
+    # Alinhado ao teste oficial do Arc SQL: DPS espera 200; telemetria espera 401
+    # (ambos tratados como reachable aqui).
+    $httpProbeEndpoints += "dataprocessingservice.$Region.arcdataservices.com"
+    $httpProbeEndpoints += "telemetry.$Region.arcdataservices.com"
+}
+
+# Mapeia grupo por endpoint para o sumario. Core tem PRECEDENCIA: se um endpoint
+# aparece em mais de um grupo (ex.: pas.windows.net em Core e WAC), mantemos 'Core'.
+$endpointGroupMap = @{}
+foreach ($ep in $coreEndpoints) { $endpointGroupMap[$ep] = 'Core' }
+foreach ($ep in $sqlEndpoints)  { if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = 'SQL' } }
+foreach ($ep in $amaEndpoints)  { if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = 'AMA' } }
+foreach ($ep in $mdeEndpoints)  { if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = 'MDE' } }
+foreach ($ep in $wacEndpoints)  { if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = 'WAC' } }
+
+# Dynamic allowlist (somente em modo publico; em PLS o trafego e via PE)
+$dynamicEndpoints = @()
+if ($Mode -eq 'Public') {
     try {
-        # Measure response time and check for 401
-        $response_time = Measure-Command { 
-            $response = Invoke-WebRequest -Uri "https://$trimmedEndpoint" -Method Get
-        }
+        Write-Log 'Buscando endpoints dinamicos do guestnotificationservice...' Info -NoCount
+        $uri  = "https://guestnotificationservice.azure.com/urls/allowlist?api-version=2020-01-01&location=$Region"
+        $resp = Invoke-WebRequestSafe -Uri $uri
+        $dynamicEndpoints = @($resp.Content | ConvertFrom-Json) | Where-Object { $_ }
+        if ($dynamicEndpoints.Count -gt 0) {
+            $totalGNS = $dynamicEndpoints.Count
 
-        if ($response.StatusCode -eq 401) {
-            # If status code is 401, treat it as expected and log it as such
-            $httpResult = "Expected (401)"
-            $httpOutput = "Success: HTTP request succeeded for $($trimmedEndpoint): $($httpResult) - Response time: $($response_time.TotalSeconds) seconds"
-            Write-Host $httpOutput -ForegroundColor Green
-            $httpOutput | Out-File -FilePath $logFilePath -Append
-        } else {
-            # For other status codes, log the actual status code
-            $httpResult = "Unexpected Status: $($response.StatusCode)"
-            $httpOutput = "Success: HTTP request succeeded for $($trimmedEndpoint): $($httpResult) - Response time: $($response_time.TotalSeconds) seconds"
-            Write-Host $httpOutput -ForegroundColor Green
-            $httpOutput | Out-File -FilePath $logFilePath -Append
-        }
-    } catch {
-        # Handle exceptions and log them
-        if ($_.Exception.Message -like "*401*") {
-            # If 401 is encountered in the exception message, treat it as expected
-            $httpResult = "Expected (401)"
-            $httpError = "Success: HTTP request succeeded for $($trimmedEndpoint) - $httpResult"
-            Write-Host $httpError -ForegroundColor Green
-            $httpError | Out-File -FilePath $logFilePath -Append
-        } else {
-            # For other exceptions, log the error message
-            $httpResult = "Error: $_"
-            $httpError = "Error: HTTP request failed for $($trimmedEndpoint) - $httpResult"
-            Write-Host $httpError -ForegroundColor Red
-            $httpError | Out-File -FilePath $logFilePath -Append
+            # Filtrar: manter apenas endpoints primarios da regiao.
+            # Namespaces primarios contem '<N>p-' (ex: 1p-, 2p-), secundarios contem '<N>s-'.
+            # Extrair cluster IDs dos primarios e filtrar children por eles.
+            $primaryClusterIds = [System.Collections.ArrayList]::new()
+            foreach ($dep in $dynamicEndpoints) {
+                if ($dep -match '^azgn-.+\dp-.+?-(\w+)\.servicebus') {
+                    [void]$primaryClusterIds.Add($Matches[1])
+                }
+            }
+
+            if ($primaryClusterIds.Count -gt 0) {
+                $filteredGNS = [System.Collections.ArrayList]::new()
+                foreach ($dep in $dynamicEndpoints) {
+                    if ($dep -match '^azgn-') {
+                        [void]$filteredGNS.Add($dep)   # sempre manter namespace-level
+                    }
+                    else {
+                        foreach ($cid in $primaryClusterIds) {
+                            if ($dep -like "*$cid*") {
+                                [void]$filteredGNS.Add($dep)
+                                break
+                            }
+                        }
+                    }
+                }
+                $skipped = $totalGNS - $filteredGNS.Count
+                $dynamicEndpoints = @($filteredGNS)
+                if ($skipped -gt 0) {
+                    Write-Log "Endpoints dinamicos obtidos: $totalGNS total, $($filteredGNS.Count) primarios ($skipped secundarios filtrados)" OK
+                }
+                else {
+                    Write-Log "Endpoints dinamicos obtidos: $totalGNS endpoint(s)" OK
+                }
+            }
+            else {
+                Write-Log "Endpoints dinamicos obtidos: $totalGNS endpoint(s)" OK
+            }
+
+            foreach ($dep in $dynamicEndpoints) {
+                $endpointGroupMap[$dep] = 'GNS'
+            }
         }
     }
-
-    "----------------------------------------" | Out-File -FilePath $logFilePath -Append
+    catch {
+        # Allowlist dinamica e AUXILIAR: sua indisponibilidade nao deve derrubar o
+        # exit code (WARN, nao FAIL). Comum ao forcar -Mode Public num host que, na
+        # pratica, roteia o GNS via Private Link / firewall.
+        Write-Log "Falha ao obter endpoints dinamicos (allowlist auxiliar): $($_.Exception.Message)" Warn
+    }
+}
+else {
+    Write-Log 'Modo Private: pulando consulta de allowlist publico.' Info -NoCount
 }
 
-# Public and Private Azure Arc check
-$publicAzureArcMessage = "Running public Azure Arc check..."
-$publicAzureArcMessage | Out-File -FilePath $logFilePath -Append
+$allEndpoints = @(
+    $coreEndpoints + $sqlEndpoints + $amaEndpoints + $mdeEndpoints +
+    $wacEndpoints + $dynamicEndpoints |
+    Where-Object { $_ } |
+    Select-Object -Unique
+)
 
-# Check if azcmagent.exe exists in the default path
-$azcmagentPath = Join-Path $env:PROGRAMFILES "AzureConnectedMachineAgent\azcmagent.exe"
-if (Test-Path $azcmagentPath) {
-    $logMessage = "Running: & $azcmagentPath check --location $($region) --cloud AzureCloud --extensions sql --enable-pls-check"
-    $logMessage | Out-File -FilePath $logFilePath -Append
-    
-    # Execute azcmagent from the correct path
-    $azcmAgentResult = & $azcmagentPath check --location $($region) --cloud AzureCloud --extensions sql --enable-pls-check
-    $azcmAgentResult | Out-File -FilePath $logFilePath -Append
-} else {
-    $errorMessage = "Error: azcmagent.exe not found in $azcmagentPath"
-    $errorMessage | Out-File -FilePath $logFilePath -Append
+Write-Log "Total de endpoints a testar: $($allEndpoints.Count)" Info -NoCount
+[void]$script:LogBuffer.Add('')
+
+# ---------------------------------------------------------------------------
+# Testes: DNS + TCP/443 (validacao de coerencia com o modo detectado)
+# ---------------------------------------------------------------------------
+foreach ($ep in $allEndpoints) {
+    $ep = $ep.Trim()
+    if (-not $ep) { continue }
+
+    [void]$script:LogBuffer.Add('-' * 60)
+    $group = if ($endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] } else { 'Dyn' }
+    Add-Result -Endpoint $ep -Group $group
+
+    # DNS (com 1 retry em falha transitoria, ex.: SERVFAIL ao resolver muitos nomes)
+    $dns = $null
+    $dnsErr = $null
+    foreach ($attempt in 1..2) {
+        try { $dns = Resolve-DnsName -Name $ep -ErrorAction Stop; $dnsErr = $null; break }
+        catch { $dnsErr = $_; if ($attempt -lt 2) { Start-Sleep -Milliseconds 300 } }
+    }
+    if ($dnsErr) {
+        # Endpoints dinamicos (GNS) sao AUXILIARES: uma falha de DNS neles vira WARN
+        # (nao FAIL), pois um SERVFAIL transitorio ao resolver dezenas de nomes
+        # 'servicebus' nao deve derrubar o exit code. Demais grupos permanecem FAIL.
+        $existingD = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+        if ($group -eq 'GNS') {
+            Write-Log "DNS WARN $ep - $($dnsErr.Exception.Message) (endpoint dinamico/auxiliar)" Warn
+            if ($existingD) { $existingD.DNS = 'WARN' }
+        }
+        else {
+            Write-Log "DNS FAIL $ep - $($dnsErr.Exception.Message)" Fail
+            if ($existingD) { $existingD.DNS = 'FAIL' }
+        }
+        continue
+    }
+
+    # Preferir IPv4 (registro A): o Azure Private Link e a maioria dos endpoints
+    # Arc sao resolvidos por A-record. Um AAAA (IPv6) publico pode coexistir com
+    # o A privado; se escolhido, causa classificacao PUBLIC incorreta e testes
+    # por um caminho IPv6 possivelmente inexistente/nao roteado.
+    $rec = $dns | Where-Object { $_.Type -eq 'A' -and $_.IPAddress } | Select-Object -First 1
+    if (-not $rec) { $rec = $dns | Where-Object IPAddress | Select-Object -First 1 }
+    $ip   = $rec.IPAddress
+    $kind = if (Test-IsPrivateIp -Ip $ip) { 'PRIVATE' } else { 'PUBLIC' }
+
+    # Update result
+    $existing = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+    if ($existing) { $existing.IP = $ip; $existing.Type = $kind }
+
+    # Alerta de mismatch DNS x modo
+    # Apenas endpoints em $canBePrivateEndpoints devem resolver para IP privado.
+    # Todos os outros (AAD, ARM, CDN, SQL, AMA, MDE, WAC, GNS) sao sempre publicos.
+    $canBePrivate = $canBePrivateEndpoints -contains $ep
+    $mismatch = $false
+    if ($Mode -eq 'Private' -and $kind -eq 'PUBLIC' -and $canBePrivate) {
+        $mismatch = $true
+    }
+    elseif ($Mode -eq 'Public' -and $kind -eq 'PRIVATE') {
+        $mismatch = $true
+    }
+    if ($mismatch) {
+        Write-Log "DNS WARN $ep -> $ip [$kind] (esperado para modo $Mode era o oposto)" Warn
+        $existing2 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+        if ($existing2) { $existing2.DNS = 'WARN' }
+    }
+    else {
+        Write-Log "DNS OK   $ep -> $ip [$kind]" OK
+        $existing2 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+        if ($existing2) { $existing2.DNS = 'OK' }
+    }
+
+    # TCP/443 (TcpClient com timeout — muito mais rapido que Test-NetConnection)
+    $tcpSw = [System.Diagnostics.Stopwatch]::StartNew()
+    $tcpOk = Test-TcpPort -ComputerName $ep -Port 443 -TimeoutMs 5000
+    $tcpSw.Stop()
+    $latencyMs = [math]::Round($tcpSw.Elapsed.TotalMilliseconds, 0)
+
+    $existing3 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+    if ($tcpOk) {
+        Write-Log "TCP OK   ${ep}:443 (${latencyMs}ms)" OK
+        if ($existing3) { $existing3.TCP = 'OK'; $existing3.Latency = "${latencyMs}ms" }
+    }
+    else {
+        Write-Log "TCP FAIL ${ep}:443 (timeout/recusado)" Fail
+        if ($existing3) { $existing3.TCP = 'FAIL'; $existing3.Latency = 'timeout' }
+    }
 }
 
-# Write end of the log
-"Script finished at $(Get-Date)" | Out-File -FilePath $logFilePath -Append
+# ---------------------------------------------------------------------------
+# Testes HTTP (401/403/400 sao considerados sucesso: endpoint exige auth)
+# Detecta azcmagent proxy.bypass para pular HTTP tests em endpoints bypassados
+# ---------------------------------------------------------------------------
+$proxyBypassCategories = @()
+$azcmPath = Get-AzcmagentPath
+if ($azcmPath -and $script:EffectiveProxy) {
+    try {
+        $bypassRaw = & $azcmPath config get proxy.bypass 2>$null
+        if ($bypassRaw -and $bypassRaw.Trim()) {
+            $bypassClean = $bypassRaw.Trim().Trim('[', ']')
+            $proxyBypassCategories = $bypassClean -split ',' | ForEach-Object { $_.Trim() }
+        }
+    }
+    catch { }
+}
+
+# Mapa de categorias de bypass -> endpoints afetados (conforme doc oficial:
+# https://learn.microsoft.com/azure/azure-arc/servers/manage-agent-proxy-settings).
+# IMPORTANTE: 'graph.microsoft.com' NAO e coberto por nenhum bypass — o agente
+# usa o proxy para ele; por isso ele NAO deve ser pulado nos testes HTTP.
+# 'ArcData' e valido a partir do agente 1.36; em versoes anteriores os endpoints
+# arcdataservices ficavam sob a categoria 'Arc'.
+$bypassCategoryEndpoints = @{
+    'AAD'     = @('login.windows.net', 'login.microsoftonline.com', 'pas.windows.net')
+    'ARM'     = @('management.azure.com')
+    'AMA'     = @(
+        'global.handler.control.monitor.azure.com'
+        "$Region.handler.control.monitor.azure.com"
+        'management.azure.com'
+        "$Region.monitoring.azure.com"
+    )
+    'Arc'     = @('gbl.his.arc.azure.com', 'agentserviceapi.guestconfiguration.azure.com')
+    'ArcData' = @(
+        "dataprocessingservice.$Region.arcdataservices.com"
+        "telemetry.$Region.arcdataservices.com"
+    )
+}
+
+$httpBypassedEndpoints = [System.Collections.ArrayList]::new()
+foreach ($cat in $proxyBypassCategories) {
+    if ($bypassCategoryEndpoints.ContainsKey($cat)) {
+        foreach ($bep in $bypassCategoryEndpoints[$cat]) {
+            [void]$httpBypassedEndpoints.Add($bep)
+        }
+    }
+}
+
+foreach ($ep in $httpProbeEndpoints) {
+    $ep = $ep.Trim()
+    if (-not $ep) { continue }
+
+    # Se o endpoint esta no bypass do azcmagent e usamos proxy, HTTP test via proxy daria falso positivo
+    if ($httpBypassedEndpoints -contains $ep) {
+        Add-Result -Endpoint $ep -HTTP 'SKIP (bypass)'
+        Write-Log "HTTP SKIP $ep (azcmagent proxy.bypass cobre este endpoint — agente nao usa proxy)" Info -NoCount
+        continue
+    }
+
+    [void]$script:LogBuffer.Add('-' * 60)
+    Add-Result -Endpoint $ep
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        $resp = Invoke-WebRequestSafe -Uri "https://$ep" -TimeoutSec 10
+        $sw.Stop()
+        $elapsed = [math]::Round($sw.Elapsed.TotalSeconds, 2)
+        Write-Log "HTTP OK  $ep -> $($resp.StatusCode) em ${elapsed}s" OK
+        $existing4 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+        if ($existing4) { $existing4.HTTP = "OK ($($resp.StatusCode))" }
+    }
+    catch {
+        $sw.Stop()
+        $code = $null
+        if ($_.Exception.Response) {
+            try { $code = [int]$_.Exception.Response.StatusCode } catch { }
+        }
+        if ($code -in 400, 401, 403, 404) {
+            Write-Log "HTTP OK  $ep -> $code (esperado sem auth/sem root handler)" OK
+            $existing4 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+            if ($existing4) { $existing4.HTTP = "OK ($code)" }
+        }
+        elseif ($code) {
+            Write-Log "HTTP FAIL $ep -> $code" Fail
+            $existing4 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+            if ($existing4) { $existing4.HTTP = "FAIL ($code)" }
+        }
+        else {
+            Write-Log "HTTP FAIL $ep - $($_.Exception.Message)" Fail
+            $existing4 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+            if ($existing4) { $existing4.HTTP = 'FAIL' }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# azcmagent check
+# ---------------------------------------------------------------------------
+[void]$script:LogBuffer.Add('=' * 60)
+$azcm = Get-AzcmagentPath
+if ($azcm) {
+    $checkArgs = @('check', '--location', $Region, '--cloud', 'AzureCloud')
+    if ($CheckIncludeAll) {
+        # Doc oficial: '--extensions' e '--include-all' sao ORTOGONAIS.
+        #   --extensions all -> endpoints de TODAS as extensoes (SQL, etc.)
+        #   --include-all    -> casos de uso ESTENDIDOS (ex.: Windows Server PAYG)
+        # Combinamos os dois para cobertura total.
+        $checkArgs += @('--extensions', 'all', '--include-all')
+    }
+    elseif ($IncludeSQL) {
+        $checkArgs += @('--extensions', 'sql')
+    }
+    if ($Mode -eq 'Private') { $checkArgs += '--enable-pls-check' }
+
+    Write-Log "Executando: azcmagent $($checkArgs -join ' ')" Info -NoCount
+    Save-LogBuffer   # garante ordem: cabecalho antes do output do binario
+    try {
+        $out = & $azcm @checkArgs 2>&1
+        Add-Content -Path $LogFilePath -Value $out
+        if ($LASTEXITCODE -eq 0) {
+            Write-Log 'azcmagent check concluido (exit 0).' OK
+        }
+        else {
+            Write-Log "azcmagent check terminou com exit $LASTEXITCODE." Fail
+        }
+    }
+    catch {
+        Write-Log "azcmagent check falhou: $($_.Exception.Message)" Fail
+    }
+}
+else {
+    Write-Log 'azcmagent.exe nao encontrado - pulando check.' Warn
+}
+
+# ---------------------------------------------------------------------------
+# Resumo
+# ---------------------------------------------------------------------------
+[void]$script:LogBuffer.Add('=' * 60)
+Write-Log ("Resumo: OK={0}  Fail={1}  Warn={2}  Modo={3}  Regiao={4}" -f `
+        $script:Stats.OK, $script:Stats.Fail, $script:Stats.Warn, $Mode, $Region) Info -NoCount
+Write-Log "Script finished at $(Get-Date -Format o)" Info -NoCount
+Save-LogBuffer
+
+# ---------------------------------------------------------------------------
+# Tabela de resultados (console + log)
+# ---------------------------------------------------------------------------
+$tableObjects = $script:Results | ForEach-Object { [pscustomobject]$_ }
+
+Write-Host ''
+Write-Host '=================== SUMARIO ===================' -ForegroundColor Cyan
+
+$rowFormat = "{0,-5} {1,-55} {2,-26} {3,-8} {4,-5} {5,-5} {6,-12} {7,-9}"
+Write-Host ($rowFormat -f 'Group', 'Endpoint', 'IP', 'Type', 'DNS', 'TCP', 'HTTP', 'Latency') -ForegroundColor Cyan
+Write-Host ($rowFormat -f ('-' * 5), ('-' * 55), ('-' * 26), ('-' * 8), ('-' * 5), ('-' * 5), ('-' * 12), ('-' * 9)) -ForegroundColor DarkGray
+
+foreach ($r in $tableObjects) {
+    $hasFail = ($r.DNS -eq 'FAIL') -or ($r.TCP -eq 'FAIL') -or ($r.HTTP -like 'FAIL*')
+    $hasWarn = ($r.DNS -eq 'WARN')
+    $color   = if ($hasFail) { 'Red' } elseif ($hasWarn) { 'Yellow' } else { 'Green' }
+    Write-Host ($rowFormat -f $r.Group, $r.Endpoint, $r.IP, $r.Type, $r.DNS, $r.TCP, $r.HTTP, $r.Latency) -ForegroundColor $color
+}
+
+Write-Host ''
+Write-Host ("Totais: OK={0}  Fail={1}  Warn={2}  Modo={3}  Regiao={4}" -f `
+        $script:Stats.OK, $script:Stats.Fail, $script:Stats.Warn, $Mode, $Region) -ForegroundColor Cyan
+
+if ($script:EffectiveProxy) {
+    Write-Host "Proxy utilizado: $($script:EffectiveProxy)" -ForegroundColor DarkGray
+}
+
+# Append tabela ao arquivo de log
+$tableString = $tableObjects | Format-Table -AutoSize | Out-String
+Add-Content -Path $LogFilePath -Value ''
+Add-Content -Path $LogFilePath -Value '=================== SUMARIO ==================='
+Add-Content -Path $LogFilePath -Value $tableString.TrimEnd()
+Add-Content -Path $LogFilePath -Value ("Totais: OK={0}  Fail={1}  Warn={2}  Modo={3}  Regiao={4}" -f `
+        $script:Stats.OK, $script:Stats.Fail, $script:Stats.Warn, $Mode, $Region)
+
+Write-Host "`nLog completo: $LogFilePath" -ForegroundColor Cyan
+exit ([int]($script:Stats.Fail -gt 0))

--- a/script_automation/arc_endpoint_check/ArcEndpointCheck.ps1
+++ b/script_automation/arc_endpoint_check/ArcEndpointCheck.ps1
@@ -2,100 +2,67 @@
 
 <#
 .SYNOPSIS
-    Validates Azure Arc connectivity, DNS resolution, and endpoint reachability
-    (public or Azure Private Link).
+    Validates Azure Arc connectivity, DNS, TCP, HTTP, TLS, proxy, PKI bypass,
+    and extension endpoints for Arc-enabled servers.
 
 .DESCRIPTION
-    - Automatically detects whether the host uses Azure Arc public endpoints or an
-      Azure Arc Private Link Scope (PLS):
-        1) 'azcmagent show -j' - if it reports a privateLinkScope => Private
-        2) otherwise, resolves 'gbl.his.arc.azure.com' and classifies as Private
-           when the IP is RFC1918 (covers the "DNS-based" Private Link scenario)
-    - Tests DNS, TCP/443, and (for selected endpoints) HTTP.
-    - Runs 'azcmagent check' with the correct flag for the detected mode.
-    - Detects and displays the proxy configuration following the agent precedence
-      (azcmagent proxy.url > HTTPS_PROXY). The Windows system-wide proxy
-      (WinHTTP/WinINET) is shown for information only, because the agent ignores it.
-    - Supports environments with Azure Firewall Explicit Proxy.
+    Auto-detects EVERYTHING: region, connectivity mode (Public/Private/Gateway),
+    proxy configuration, installed extensions, and regional endpoints.
+
+    Connectivity modes supported (per Microsoft docs):
+      - Public:  Direct internet or via forward proxy
+      - Private: Azure Private Link Scope (PLS)
+      - Gateway: Azure Arc Gateway (reduces endpoints to ~7 FQDNs)
+
+    Validates:
+      - Core Arc agent endpoints (HIMDS, GuestConfig, GNS, AAD, ARM)
+      - Regional endpoints discovered from 'azcmagent check'
+      - PKI/OCSP/CRL proxy bypass (detects "non-proxy request on proxy port")
+      - TLS version (1.2+ required per Microsoft docs)
+      - Extension endpoints based on installed extensions (auto-detected)
+      - Arc Gateway URL when gateway mode is active
+
+    Run with ZERO parameters for full auto-detection:
+      PS> .\arcendpointcheck.ps1
 
 .PARAMETER Region
-    Azure region (default: eastus2).
+    Azure region. Auto-detected from azcmagent if omitted.
 
 .PARAMETER Mode
-    Auto | Public | Private. Default: Auto.
+    Auto | Public | Private | Gateway. Default: Auto.
 
 .PARAMETER ProxyUrl
-    HTTP/HTTPS proxy URL (e.g., http://10.0.1.4:8443). If omitted, the script
-    auto-detects using the same precedence as the Azure Arc agent: 1) azcmagent
-    proxy.url (agent config - takes precedence); 2) the HTTPS_PROXY environment
-    variable. The Windows system-wide proxy (WinHTTP/WinINET) is only reported,
-    never applied automatically - mirroring the agent.
-    Ref: https://learn.microsoft.com/azure/azure-arc/servers/manage-agent-proxy-settings
+    Override proxy URL. Auto-detected if omitted.
 
 .PARAMETER LogFilePath
     Log file path. Default: C:\temp\Arclogfile.txt.
 
-.PARAMETER IncludeSQL
-    Includes Azure Arc-enabled SQL Server endpoints: data processing service and
-    telemetry (*.arcdataservices.com), san-af (legacy), and graph.microsoft.com
-    (Microsoft Entra authentication). Aligned with the official Arc SQL connectivity
-    test (DPS => 200, telemetry => 401).
+.PARAMETER SkipPKI
+    Skips PKI/OCSP/CRL testing (not recommended).
 
-.PARAMETER IncludeAMA
-    Includes Azure Monitor Agent (AMA) endpoints.
-
-.PARAMETER IncludeMDE
-    Includes Microsoft Defender for Endpoint endpoints.
-
-.PARAMETER IncludeWAC
-    Includes Windows Admin Center endpoints.
+.PARAMETER SkipExtensions
+    Skips extension endpoint testing.
 
 .PARAMETER CheckIncludeAll
-    Makes 'azcmagent check' validate everything: adds '--extensions all' (endpoints
-    for all supported extensions) and '--include-all' (extended use cases, e.g.,
-    Windows Server pay-as-you-go). Useful before onboarding. Replaces the
-    '--extensions sql' that -IncludeSQL would add.
+    Makes 'azcmagent check' use '--extensions all --include-all'.
 
 .EXAMPLE
-    PS> .\ArcEndpointCheck.ps1
-    Auto-detects the mode (Public/Private) and uses the default region 'eastus2'.
+    PS> .\arcendpointcheck.ps1
+    Full auto: detects region, mode, proxy, extensions. Zero parameters needed.
 
 .EXAMPLE
-    PS> .\ArcEndpointCheck.ps1 -Region brazilsouth -IncludeSQL -IncludeAMA
-    Runs against brazilsouth including SQL and AMA endpoints.
+    PS> .\arcendpointcheck.ps1 -Region brazilsouth -Mode Private
+    Forces region and mode override.
 
 .EXAMPLE
-    PS> .\ArcEndpointCheck.ps1 -Region eastus2 -ProxyUrl http://10.0.1.4:8443
-    Forces an explicit proxy for all HTTP tests.
-
-.EXAMPLE
-    PS> .\ArcEndpointCheck.ps1 -Region westeurope -Mode Public
-    Forces Public mode on westeurope (useful to validate the internet endpoint
-    list when the host does not have the agent installed yet).
-
-.EXAMPLE
-    PS> .\ArcEndpointCheck.ps1 -Region brazilsouth -Mode Private -LogFilePath D:\logs\arc-pls.txt
-    Forces Private Link validation and writes the log to a custom path. Adds the
-    '--enable-pls-check' flag to 'azcmagent check'.
-
-.EXAMPLE
-    PS> .\ArcEndpointCheck.ps1 -Region southcentralus -Verbose -IncludeSQL -IncludeAMA -IncludeMDE -IncludeWAC
-    Runs with detailed verbose output and all endpoint groups.
-    Common regions: eastus, eastus2, westus2, westus3, centralus, northeurope,
-    westeurope, uksouth, francecentral, switzerlandnorth, southeastasia,
-    japaneast, australiaeast, brazilsouth, southafricanorth, uaenorth.
-
-.EXAMPLE
-    PS> .\ArcEndpointCheck.ps1 -Mode Private -CheckIncludeAll
-    Runs 'azcmagent check' with '--extensions all --include-all' (endpoints for all
-    extensions + extended use cases) in Private mode.
+    PS> .\arcendpointcheck.ps1 -Region eastus2 -Mode Private -ProxyUrl http://10.0.1.4:8443 -CheckIncludeAll
+    Pre-onboarding: agent not installed. Specify region, mode, proxy, and test all extensions.
 
 .NOTES
-    Requires PowerShell 5.1+ on Windows (uses netsh, Resolve-DnsName, and azcmagent.exe).
-    azcmagent.exe is optional (only for the final check).
-    Exit code: 0 = all tests OK; 1 = at least one failure.
-    Endpoint lists aligned with the Connected Machine agent network requirements and
-    its extensions (AMA/SQL/MDE/WAC).
+    Requires PowerShell 5.1+ on Windows.
+    Ref: https://learn.microsoft.com/azure/azure-arc/network-requirements-consolidated
+         https://learn.microsoft.com/azure/azure-arc/servers/arc-gateway
+         https://learn.microsoft.com/azure/azure-arc/azure-firewall-explicit-proxy
 
 .LINK
     https://azurearcjumpstart.com
@@ -103,844 +70,1373 @@
 
 [CmdletBinding()]
 param(
-    [string]$Region = 'eastus2',
+    [string]$Region = '',
 
-    [ValidateSet('Auto', 'Public', 'Private')]
+    [ValidateSet('Auto', 'Public', 'Private', 'Gateway')]
     [string]$Mode = 'Auto',
 
     [string]$ProxyUrl,
 
-    [string]$LogFilePath = 'C:\temp\Arclogfile.txt',
+    [string]$LogFilePath = "C:\temp\ArcEndpointCheck_$($env:COMPUTERNAME).txt",
 
-    [switch]$IncludeSQL,
-    [switch]$IncludeAMA,
-    [switch]$IncludeMDE,
-    [switch]$IncludeWAC,
-
+    [switch]$SkipPKI,
+    [switch]$SkipExtensions,
     [switch]$CheckIncludeAll
 )
 
-# ---------------------------------------------------------------------------
-# Setup
-# ---------------------------------------------------------------------------
+# =========================================================================
+# SETUP
+# =========================================================================
 $ErrorActionPreference = 'Stop'
-$ProgressPreference    = 'SilentlyContinue'   # speeds up Invoke-WebRequest and Test-NetConnection
+$ProgressPreference    = 'SilentlyContinue'
 
 $logDir = Split-Path -Path $LogFilePath -Parent
 if ($logDir -and -not (Test-Path $logDir)) {
     New-Item -ItemType Directory -Path $logDir -Force | Out-Null
 }
-Set-Content -Path $LogFilePath -Value "Script started at $(Get-Date -Format o)" -Force
+Set-Content -Path $LogFilePath -Value "ArcEndpointCheck started at $(Get-Date -Format o)" -Force
 
-$script:Stats     = [ordered]@{ OK = 0; Fail = 0; Warn = 0 }
-$script:LogBuffer = [System.Collections.ArrayList]::new()
-$script:Results   = [System.Collections.ArrayList]::new()
+$script:Stats   = [ordered]@{ OK = 0; Fail = 0; Warn = 0 }
+$script:Log      = [System.Collections.ArrayList]::new()
+$script:Results  = [System.Collections.ArrayList]::new()
+$script:Issues   = [System.Collections.ArrayList]::new()
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+# =========================================================================
+# HELPERS
+# =========================================================================
+
+function Write-Banner {
+    param([string]$T)
+    $w = 74
+    Write-Host ''
+    Write-Host ('=' * $w) -ForegroundColor DarkCyan
+    Write-Host "  $T" -ForegroundColor Cyan
+    Write-Host ('=' * $w) -ForegroundColor DarkCyan
+}
+
+function Write-Section {
+    param([string]$T)
+    Write-Host ''
+    Write-Host "  --- $T ---" -ForegroundColor DarkGray
+}
+
+function Write-Status {
+    param([string]$Label, [string]$Value, [string]$Color = 'White')
+    Write-Host ("  {0,-22} {1}" -f "${Label}:", $Value) -ForegroundColor $Color
+}
 
 function Test-IsValidProxyUri {
-    <#
-    .SYNOPSIS
-        Returns $true only when the input is a well-formed absolute http:// or
-        https:// URI. Rejects informational strings that azcmagent returns when
-        the proxy is not configured (e.g. "proxy.url has not been set").
-    #>
-    param([string]$Candidate)
-    if (-not $Candidate) { return $false }
-    $parsed = $null
+    param([string]$C)
+    if (-not $C) { return $false }
+    $p = $null
     return (
-        [System.Uri]::TryCreate($Candidate, [System.UriKind]::Absolute, [ref]$parsed) -and
-        $parsed.Scheme -in @('http', 'https')
+        [System.Uri]::TryCreate($C, [System.UriKind]::Absolute, [ref]$p) -and
+        $p.Scheme -in @('http', 'https')
     )
+}
+
+function Log {
+    param(
+        [string]$Msg,
+        [ValidateSet('Info', 'OK', 'Fail', 'Warn')][string]$Lv = 'Info',
+        [switch]$NoCount
+    )
+    $line = "[$(Get-Date -Format HH:mm:ss)] [$($Lv.ToUpper().PadRight(4))] $Msg"
+    [void]$script:Log.Add($line)
+    Write-Verbose $line
+    if (-not $NoCount) {
+        if ($Lv -eq 'OK')   { $script:Stats.OK++ }
+        if ($Lv -eq 'Fail') { $script:Stats.Fail++ }
+        if ($Lv -eq 'Warn') { $script:Stats.Warn++ }
+    }
 }
 
 function Add-Result {
     param(
-        [Parameter(Mandatory)] [string]$Endpoint,
-        [string]$Group = 'Core',
-        [string]$IP    = '-',
-        [string]$Type  = '-',
-        [string]$DNS   = '-',
-        [string]$TCP   = '-',
-        [string]$HTTP  = '-',
-        [string]$Latency = '-'
+        [string]$Endpoint, [string]$Group = 'Core', [string]$IP = '-',
+        [string]$Type = '-', [string]$DNS = '-', [string]$TCP = '-',
+        [string]$HTTP = '-', [string]$Latency = '-'
     )
-    # Check if endpoint already exists and update
-    $existing = $script:Results | Where-Object { $_.Endpoint -eq $Endpoint }
-    if ($existing) {
-        if ($IP      -ne '-') { $existing.IP      = $IP }
-        if ($Type    -ne '-') { $existing.Type    = $Type }
-        if ($DNS     -ne '-') { $existing.DNS     = $DNS }
-        if ($TCP     -ne '-') { $existing.TCP     = $TCP }
-        if ($HTTP    -ne '-') { $existing.HTTP    = $HTTP }
-        if ($Latency -ne '-') { $existing.Latency = $Latency }
+    $ex = $script:Results | Where-Object { $_.Endpoint -eq $Endpoint }
+    if ($ex) {
+        if ($IP      -ne '-') { $ex.IP      = $IP }
+        if ($Type    -ne '-') { $ex.Type    = $Type }
+        if ($DNS     -ne '-') { $ex.DNS     = $DNS }
+        if ($TCP     -ne '-') { $ex.TCP     = $TCP }
+        if ($HTTP    -ne '-') { $ex.HTTP    = $HTTP }
+        if ($Latency -ne '-') { $ex.Latency = $Latency }
     }
     else {
         [void]$script:Results.Add([ordered]@{
-            Endpoint = $Endpoint
-            Group    = $Group
-            IP       = $IP
-            Type     = $Type
-            DNS      = $DNS
-            TCP      = $TCP
-            HTTP     = $HTTP
-            Latency  = $Latency
+            Endpoint = $Endpoint; Group = $Group; IP = $IP; Type = $Type
+            DNS = $DNS; TCP = $TCP; HTTP = $HTTP; Latency = $Latency
         })
     }
 }
 
-function Write-Log {
-    param(
-        [Parameter(Mandatory)] [string]$Message,
-        [ValidateSet('Info', 'OK', 'Fail', 'Warn')] [string]$Level = 'Info',
-        [switch]$NoCount
-    )
-    $color = @{ Info = 'Gray'; OK = 'Green'; Fail = 'Red'; Warn = 'Yellow' }[$Level]
-    $line  = "[{0}] [{1,-4}] {2}" -f (Get-Date -Format HH:mm:ss), $Level.ToUpper(), $Message
-    Write-Host $line -ForegroundColor $color
-    [void]$script:LogBuffer.Add($line)
-
-    if (-not $NoCount) {
-        if ($Level -eq 'OK')   { $script:Stats.OK++ }
-        if ($Level -eq 'Fail') { $script:Stats.Fail++ }
-        if ($Level -eq 'Warn') { $script:Stats.Warn++ }
-    }
+function Add-Issue {
+    param([string]$Sev, [string]$Cat, [string]$Msg, [string]$Fix = '')
+    [void]$script:Issues.Add([ordered]@{
+        Severity = $Sev; Category = $Cat; Message = $Msg; Fix = $Fix
+    })
 }
 
-function Save-LogBuffer {
-    if ($script:LogBuffer.Count -gt 0) {
-        Add-Content -Path $LogFilePath -Value $script:LogBuffer
-        $script:LogBuffer.Clear()
+function Save-Log {
+    if ($script:Log.Count -gt 0) {
+        Add-Content -Path $LogFilePath -Value $script:Log
+        $script:Log.Clear()
     }
 }
 
 function Test-TcpPort {
-    param(
-        [Parameter(Mandatory)] [string]$ComputerName,
-        [int]$Port = 443,
-        [int]$TimeoutMs = 5000
-    )
-    $client = [System.Net.Sockets.TcpClient]::new()
+    param([string]$H, [int]$P = 443, [int]$T = 5000)
+    $c = [System.Net.Sockets.TcpClient]::new()
     try {
-        $iar = $client.BeginConnect($ComputerName, $Port, $null, $null)
-        if ($iar.AsyncWaitHandle.WaitOne($TimeoutMs, $false) -and $client.Connected) {
-            $client.EndConnect($iar) | Out-Null
+        $r = $c.BeginConnect($H, $P, $null, $null)
+        if ($r.AsyncWaitHandle.WaitOne($T, $false) -and $c.Connected) {
+            $c.EndConnect($r) | Out-Null
             return $true
         }
         return $false
     }
     catch { return $false }
-    finally { $client.Close() }
+    finally { $c.Close() }
 }
 
-function Invoke-WebRequestSafe {
-    param(
-        [Parameter(Mandatory)] [string]$Uri,
-        [int]$TimeoutSec = 10
-    )
-    $params = @{
-        Uri             = $Uri
-        Method          = 'Get'
-        UseBasicParsing = $true
-        TimeoutSec      = $TimeoutSec
-        ErrorAction     = 'Stop'
+function Invoke-HttpSafe {
+    param([string]$Uri, [int]$Timeout = 10, [string]$UseProxy = '')
+    $p = @{
+        Uri = $Uri; Method = 'Get'; UseBasicParsing = $true
+        TimeoutSec = $Timeout; ErrorAction = 'Stop'
     }
-    if ($script:EffectiveProxy) {
-        $params['Proxy'] = $script:EffectiveProxy
-        $params['ProxyUseDefaultCredentials'] = $true
+    $px = if ($UseProxy) { $UseProxy } else { $script:EffectiveProxy }
+    if ($px) {
+        $p['Proxy'] = $px
+        $p['ProxyUseDefaultCredentials'] = $true
     }
     elseif ($PSVersionTable.PSVersion.Major -ge 6) {
-        # PS 6+: mirror the agent, which IGNORES the system-wide proxy. On PS 5.1 the
-        # same effect is achieved by neutralizing .NET's DefaultWebProxy during setup.
-        $params['NoProxy'] = $true
+        $p['NoProxy'] = $true
     }
-    return Invoke-WebRequest @params
+    Invoke-WebRequest @p
 }
 
-# ---------------------------------------------------------------------------
-# Proxy detection and display
-# ---------------------------------------------------------------------------
-$script:EffectiveProxy = $null
-
-function Get-ProxyDiagnostics {
-    Write-Log '=== PROXY DIAGNOSTICS ===' Info -NoCount
-    [void]$script:LogBuffer.Add('')
-
-    # Effective proxy precedence (used by this script's HTTP tests) — mirrors the
-    # behavior of the Azure Connected Machine agent on Windows:
-    #   1) -ProxyUrl            (explicit operator override)
-    #   2) azcmagent proxy.url  (agent config — TAKES PRECEDENCE over env vars)
-    #   3) HTTPS_PROXY (env)    (system-wide)
-    # The agent IGNORES the Windows system-wide proxy (WinHTTP/WinINET); that is why
-    # the WinHTTP value below is only REPORTED, never applied automatically.
-    # Ref: https://learn.microsoft.com/azure/azure-arc/servers/manage-agent-proxy-settings
-
-    # 1) -ProxyUrl parameter (validated as an absolute http/https URI)
-    if ($ProxyUrl) {
-        if (Test-IsValidProxyUri -Candidate $ProxyUrl) {
-            Write-Log "Proxy from parameter: $ProxyUrl" Info -NoCount
-            $script:EffectiveProxy = $ProxyUrl
-        }
-        else {
-            Write-Log "Proxy from parameter INVALID (expected http:// or https://): $ProxyUrl" Warn
-        }
-    }
-
-    # WinHTTP (informational only — the agent ignores the system-wide proxy)
-    # Bilingual regex: EN "Proxy Server(s)" / pt-BR "Servidor(es) Proxy"
-    try {
-        $winhttp = netsh winhttp show proxy 2>$null
-        $winhttpText = ($winhttp | Out-String).Trim()
-        if ($winhttpText -match 'Proxy Server\(s\)\s*:\s*(.+)|Servidor\(es\) Proxy\s*:\s*(.+)') {
-            $winhttpProxy = ($Matches[1], $Matches[2] | Where-Object { $_ } | Select-Object -First 1).Trim()
-            Write-Log "WinHTTP Proxy: $winhttpProxy (informational — the agent ignores the system-wide proxy)" Info -NoCount
-        }
-        else {
-            Write-Log 'WinHTTP Proxy: Direct (no proxy)' Info -NoCount
-        }
-        if ($winhttpText -match 'Bypass List\s*:\s*(.+)|Lista de bypass\s*:\s*(.+)') {
-            $bypassVal = ($Matches[1], $Matches[2] | Where-Object { $_ } | Select-Object -First 1).Trim()
-            Write-Log "WinHTTP Bypass: $bypassVal" Info -NoCount
-        }
-    }
-    catch {
-        Write-Log "WinHTTP: unable to query ($($_.Exception.Message))" Warn
-    }
-
-    # 2) azcmagent config (proxy.url TAKES PRECEDENCE over HTTPS_PROXY)
-    #    IMPORTANT: azcmagent returns informational phrases when the value is not
-    #    configured (e.g. "proxy.url has not been set"). We validate with
-    #    Test-IsValidProxyUri to accept ONLY real http/https URIs.
-    $azcm = Get-AzcmagentPath
-    if ($azcm) {
-        try {
-            $rawProxyUrl = & $azcm config get proxy.url 2>$null
-            $rawProxyUrlTrimmed = if ($rawProxyUrl) { ($rawProxyUrl | Out-String).Trim() } else { '' }
-
-            if (Test-IsValidProxyUri -Candidate $rawProxyUrlTrimmed) {
-                Write-Log "azcmagent proxy.url: $rawProxyUrlTrimmed" Info -NoCount
-                if (-not $script:EffectiveProxy) {
-                    $script:EffectiveProxy = $rawProxyUrlTrimmed
-                }
-            }
-            else {
-                # Informational message (e.g. "proxy.url has not been set")
-                if ($rawProxyUrlTrimmed) {
-                    Write-Log "azcmagent proxy.url: $rawProxyUrlTrimmed" Info -NoCount
-                }
-                else {
-                    Write-Log 'azcmagent proxy.url: (not configured)' Info -NoCount
-                }
-            }
-
-            $bypass = & $azcm config get proxy.bypass 2>$null
-            $bypassTrimmed = if ($bypass) { ($bypass | Out-String).Trim() } else { '' }
-            if ($bypassTrimmed) {
-                Write-Log "azcmagent proxy.bypass: $bypassTrimmed" Info -NoCount
-            }
-        }
-        catch {
-            Write-Log "azcmagent config: failed to query ($($_.Exception.Message))" Warn
-        }
-    }
-
-    # 3) Environment variables (checks Machine -> Process -> User)
-    $envProxy = [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'Machine')
-    if (-not $envProxy) { $envProxy = [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'Process') }
-    if (-not $envProxy) { $envProxy = [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'User') }
-    $envNoProxy = [Environment]::GetEnvironmentVariable('NO_PROXY', 'Machine')
-    if (-not $envNoProxy) { $envNoProxy = [Environment]::GetEnvironmentVariable('NO_PROXY', 'Process') }
-    if (-not $envNoProxy) { $envNoProxy = [Environment]::GetEnvironmentVariable('NO_PROXY', 'User') }
-    if ($envProxy) {
-        Write-Log "Env HTTPS_PROXY: $envProxy" Info -NoCount
-        if (-not $script:EffectiveProxy) {
-            if (Test-IsValidProxyUri -Candidate $envProxy) {
-                $script:EffectiveProxy = $envProxy
-            }
-            else {
-                Write-Log "Env HTTPS_PROXY INVALID (expected http:// or https://): $envProxy" Warn
-            }
-        }
-    }
-    else {
-        Write-Log 'Env HTTPS_PROXY: (not set)' Info -NoCount
-    }
-    if ($envNoProxy) {
-        Write-Log "Env NO_PROXY: $envNoProxy" Info -NoCount
-    }
-
-    if ($script:EffectiveProxy) {
-        Write-Log "Effective proxy for HTTP tests: $($script:EffectiveProxy)" Info -NoCount
-    }
-    else {
-        Write-Log 'Effective proxy: Direct (no proxy — HTTP tests go direct, like the agent)' Info -NoCount
-    }
-
-    [void]$script:LogBuffer.Add('')
-}
-
-# ---------------------------------------------------------------------------
-# Automatic Public vs Private detection
-# ---------------------------------------------------------------------------
 function Get-AzcmagentPath {
-    $candidate = Join-Path $env:ProgramFiles 'AzureConnectedMachineAgent\azcmagent.exe'
-    if (Test-Path $candidate) { return $candidate }
+    $c = Join-Path $env:ProgramFiles 'AzureConnectedMachineAgent\azcmagent.exe'
+    if (Test-Path $c) { return $c }
     return $null
 }
 
 function Test-IsPrivateIp {
     param([string]$Ip)
     if (-not $Ip) { return $false }
-    try {
-        $bytes = ([System.Net.IPAddress]::Parse($Ip)).GetAddressBytes()
-    }
+    try { $b = ([System.Net.IPAddress]::Parse($Ip)).GetAddressBytes() }
     catch { return $false }
-
-    # RFC1918 + 100.64/10 (CGNAT, common in corporate networks)
-    return ($bytes[0] -eq 10) -or
-           ($bytes[0] -eq 192 -and $bytes[1] -eq 168) -or
-           ($bytes[0] -eq 172 -and $bytes[1] -ge 16 -and $bytes[1] -le 31) -or
-           ($bytes[0] -eq 100 -and $bytes[1] -ge 64 -and $bytes[1] -le 127)
+    return ($b[0] -eq 10) -or
+           ($b[0] -eq 192 -and $b[1] -eq 168) -or
+           ($b[0] -eq 172 -and $b[1] -ge 16 -and $b[1] -le 31) -or
+           ($b[0] -eq 100 -and $b[1] -ge 64 -and $b[1] -le 127)
 }
 
-function Resolve-ArcMode {
-    Write-Log 'Detecting Arc mode (Public/Private)...' Info -NoCount
+# =========================================================================
+# 1. AGENT DETECTION (region, mode, gateway, extensions)
+# =========================================================================
 
-    # 1) Via azcmagent show -j
-    $azcm = Get-AzcmagentPath
-    if ($azcm) {
-        try {
-            $json = & $azcm show -j 2>$null | ConvertFrom-Json
-            $pls = $json.privateLinkScope
-            if ($pls) {
-                Write-Log "azcmagent reports privateLinkScope: $pls" Info -NoCount
-                return 'Private'
-            }
-            else {
-                # Do NOT conclude Public here: fall through to the DNS heuristic below.
-                # Private Link can be "DNS-based" (Private DNS Zones) without the agent
-                # exposing the PLS locally in 'azcmagent show -j'.
-                Write-Log 'azcmagent does not report privateLinkScope; confirming via DNS...' Info -NoCount
-            }
+Write-Banner 'AZURE ARC ENDPOINT CHECK'
+Write-Status 'Host' $env:COMPUTERNAME
+Write-Status 'Time' (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+
+$script:EffectiveProxy = $null
+$script:WinHttpProxy   = $null
+$script:WinHttpBypass  = $null
+$script:AgentJson      = $null
+$script:GatewayUrl     = $null
+$script:InstalledExts  = @()
+
+$azcm = Get-AzcmagentPath
+$script:PreOnboarding = (-not $azcm)
+if ($azcm) {
+    try { $script:AgentJson = & $azcm show -j 2>$null | ConvertFrom-Json } catch { }
+}
+
+# --- Pre-onboarding warning ---
+if ($script:PreOnboarding) {
+    Write-Host ''
+    Write-Host '  ** PRE-ONBOARDING MODE **' -ForegroundColor Yellow
+    Write-Host '  azcmagent not installed. Region, mode, and extensions' -ForegroundColor Yellow
+    Write-Host '  cannot be auto-detected. Use parameters to override:' -ForegroundColor Yellow
+    Write-Host '    -Region <region>  -Mode <Public|Private|Gateway>' -ForegroundColor DarkYellow
+    Write-Host '    -CheckIncludeAll  (tests ALL extension endpoints)' -ForegroundColor DarkYellow
+    Write-Host '    -ProxyUrl <url>   (if proxy is not yet in WinHTTP/env)' -ForegroundColor DarkYellow
+    Write-Host ''
+}
+
+if ($azcm -and $script:AgentJson) {
+    $agSt  = if ($script:AgentJson.PSObject.Properties['status']) { $script:AgentJson.status } else { $null }
+    $agVer = if ($script:AgentJson.PSObject.Properties['agentVersion']) { $script:AgentJson.agentVersion } else { $null }
+    $agParts = @('Installed')
+    if ($agSt)  { $agParts += $agSt }
+    if ($agVer) { $agParts += "v$agVer" }
+    $agColor = if ($agSt -eq 'Connected') { 'Green' } elseif ($agSt -eq 'Disconnected') { 'Red' } else { 'Yellow' }
+    Write-Status 'Agent' ($agParts -join ' | ') $agColor
+}
+elseif ($azcm) {
+    Write-Status 'Agent' 'Installed (could not read status)' Yellow
+}
+else {
+    Write-Status 'Agent' 'NOT INSTALLED (pre-onboarding)' Yellow
+}
+
+# --- Region ---
+if (-not $Region) {
+    if ($script:AgentJson -and $script:AgentJson.location) {
+        $Region = $script:AgentJson.location
+        Write-Status 'Region' "$Region (auto-detected)" Green
+    }
+    else {
+        $Region = 'eastus2'
+        Write-Status 'Region' "$Region (default - use -Region to override)" Yellow
+    }
+}
+else {
+    Write-Status 'Region' "$Region (specified)" White
+}
+
+# --- Mode ---
+if ($Mode -eq 'Auto') {
+    if ($script:AgentJson) {
+        # Check for Gateway mode
+        $gwUrl    = if ($script:AgentJson.PSObject.Properties['gatewayUrl'])    { $script:AgentJson.gatewayUrl }
+                    elseif ($script:AgentJson.PSObject.Properties['gatewayurl']) { $script:AgentJson.gatewayurl }
+                    else { $null }
+        $connType = if ($script:AgentJson.PSObject.Properties['connectionType'])    { $script:AgentJson.connectionType }
+                    elseif ($script:AgentJson.PSObject.Properties['connectiontype']) { $script:AgentJson.connectiontype }
+                    else { $null }
+        $plsVal   = if ($script:AgentJson.PSObject.Properties['privateLinkScope'])    { $script:AgentJson.privateLinkScope }
+                    elseif ($script:AgentJson.PSObject.Properties['privatelinkscope']) { $script:AgentJson.privatelinkscope }
+                    else { $null }
+
+        if ($gwUrl -or $connType -eq 'gateway') {
+            $Mode = 'Gateway'
+            $script:GatewayUrl = $gwUrl
         }
-        catch {
-            Write-Log "Failed to query azcmagent show -j: $($_.Exception.Message). Falling back to DNS." Warn
+        elseif ($plsVal) {
+            $Mode = 'Private'
+        }
+        else {
+            # DNS heuristic fallback
+            try {
+                $dns = Resolve-DnsName -Name 'gbl.his.arc.azure.com' -Type A -ErrorAction Stop
+                $ip  = ($dns | Where-Object { $_.Type -eq 'A' -and $_.IPAddress } | Select-Object -First 1).IPAddress
+                $Mode = if (Test-IsPrivateIp -Ip $ip) { 'Private' } else { 'Public' }
+            }
+            catch { $Mode = 'Public' }
         }
     }
     else {
-        Write-Log 'azcmagent.exe not found. Using DNS fallback.' Warn
-    }
-
-    # 2) Fallback: resolve gbl.his.arc.azure.com
-    try {
-        $dns = Resolve-DnsName -Name 'gbl.his.arc.azure.com' -Type A -ErrorAction Stop
-        $ip  = ($dns | Where-Object IPAddress | Select-Object -First 1).IPAddress
-        if (Test-IsPrivateIp -Ip $ip) {
-            Write-Log "gbl.his.arc.azure.com resolves to a private IP ($ip) -> Private Link" Info -NoCount
-            return 'Private'
+        # No agent — use DNS heuristic to detect Private Link
+        try {
+            $dns = Resolve-DnsName -Name 'gbl.his.arc.azure.com' -Type A -ErrorAction Stop
+            $ip  = ($dns | Where-Object { $_.Type -eq 'A' -and $_.IPAddress } | Select-Object -First 1).IPAddress
+            $Mode = if (Test-IsPrivateIp -Ip $ip) { 'Private' } else { 'Public' }
         }
-        else {
-            Write-Log "gbl.his.arc.azure.com resolves to a public IP ($ip) -> Public" Info -NoCount
-            return 'Public'
-        }
-    }
-    catch {
-        Write-Log 'Could not resolve gbl.his.arc.azure.com - assuming Public.' Warn
-        return 'Public'
+        catch { $Mode = 'Public' }
     }
 }
 
-# ---------------------------------------------------------------------------
-# Mode and proxy detection
-# ---------------------------------------------------------------------------
-Get-ProxyDiagnostics
+$modeColor = switch ($Mode) {
+    'Private' { 'Magenta' }
+    'Gateway' { 'DarkYellow' }
+    default   { 'Green' }
+}
+Write-Status 'Mode' $Mode $modeColor
 
-# Alignment with the agent: the Azure Connected Machine agent IGNORES the Windows
-# system-wide proxy (WinINET/WinHTTP). If no effective proxy was detected, we
-# neutralize .NET's DefaultWebProxy (PS 5.1) so that the HTTP tests also go direct.
-# On PS 6+ this is done via -NoProxy.
+if ($script:GatewayUrl) {
+    Write-Status 'Gateway' $script:GatewayUrl DarkYellow
+}
+
+# --- Installed Extensions (auto-detect) ---
+if (-not $SkipExtensions -and $azcm) {
+    try {
+        $extOut = & $azcm extension list 2>$null
+        if ($extOut) {
+            $extLines = $extOut | Out-String
+            if ($extLines -match 'WindowsAgent\.SqlServer|LinuxAgent\.SqlServer|SqlServer')       { $script:InstalledExts += 'SQL' }
+            if ($extLines -match 'AzureMonitor|AMA')                                              { $script:InstalledExts += 'AMA' }
+            if ($extLines -match 'MDE|DefenderForServers|AzureDefender')                           { $script:InstalledExts += 'MDE' }
+            if ($extLines -match 'AdminCenter')                                                   { $script:InstalledExts += 'WAC' }
+            if ($extLines -match 'KeyVault')                                                      { $script:InstalledExts += 'KV' }
+            if ($extLines -match 'HybridWorker|Automation')                                       { $script:InstalledExts += 'HRW' }
+            if ($extLines -match 'ChangeTracking')                                                { $script:InstalledExts += 'CT' }
+            if ($extLines -match 'GuestAttestation|WindowsAttestation|LinuxAttestation')           { $script:InstalledExts += 'GA' }
+            if ($extLines -match 'WindowsPatchExtension|LinuxPatchExtension|UpdateManagement')     { $script:InstalledExts += 'UM' }
+            if ($extLines -match 'CustomScript')                                                  { $script:InstalledExts += 'CS' }
+            if ($extLines -match 'DependencyAgent')                                               { $script:InstalledExts += 'DA' }
+            if ($extLines -match 'DefenderForSQL|AdvancedThreatProtection|MicrosoftDefenderForSQL') { $script:InstalledExts += 'DSQL' }
+        }
+    }
+    catch { }
+}
+
+if ($script:InstalledExts.Count -gt 0) {
+    Write-Status 'Extensions' ($script:InstalledExts -join ', ') White
+}
+else {
+    if ($script:PreOnboarding) {
+        if ($CheckIncludeAll) {
+            Write-Status 'Extensions' '(all - pre-onboarding with -CheckIncludeAll)' DarkYellow
+        }
+        else {
+            Write-Status 'Extensions' '(none - use -CheckIncludeAll to test all)' Yellow
+        }
+    }
+    else {
+        Write-Status 'Extensions' '(none detected)' DarkGray
+    }
+}
+
+# =========================================================================
+# 2. PROXY DETECTION
+# =========================================================================
+
+Write-Section 'Proxy Configuration'
+
+# --- WinHTTP ---
+try {
+    $wh = netsh winhttp show proxy 2>$null | Out-String
+    if ($wh -match 'Proxy Server\(s\)\s*:\s*(.+)|Servidor\(es\) Proxy\s*:\s*(.+)') {
+        $script:WinHttpProxy = ($Matches[1], $Matches[2] | Where-Object { $_ } | Select-Object -First 1).Trim()
+    }
+    # Generic URL fallback for unrecognized locales (FR, DE, ES, JP, etc.)
+    if (-not $script:WinHttpProxy -and $wh -notmatch 'Direct|direct|Direto|direto|Direkt' -and $wh -match '(https?://[^\s;]+)') {
+        $script:WinHttpProxy = $Matches[1].Trim()
+    }
+    if ($wh -match 'Bypass List\s*:\s*(.+)|Lista de bypass\s*:\s*(.+)') {
+        $script:WinHttpBypass = ($Matches[1], $Matches[2] | Where-Object { $_ } | Select-Object -First 1).Trim()
+    }
+}
+catch { }
+
+# --- Agent proxy ---
+$agentProxy = $null
+$agentBypass = $null
+if ($azcm) {
+    try {
+        $raw = & $azcm config get proxy.url 2>$null | Out-String
+        $raw = $raw.Trim()
+        if (Test-IsValidProxyUri $raw) { $agentProxy = $raw }
+        $agentBypass = (& $azcm config get proxy.bypass 2>$null | Out-String).Trim()
+    }
+    catch { }
+}
+
+# --- Env vars ---
+$envProxy   = [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'Machine')
+if (-not $envProxy) { $envProxy = [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'Process') }
+$envNoProxy = [Environment]::GetEnvironmentVariable('NO_PROXY', 'Machine')
+if (-not $envNoProxy) { $envNoProxy = [Environment]::GetEnvironmentVariable('NO_PROXY', 'Process') }
+
+# --- Effective proxy (precedence: -ProxyUrl > azcmagent > HTTPS_PROXY > WinHTTP) ---
+if ($ProxyUrl -and (Test-IsValidProxyUri $ProxyUrl)) {
+    $script:EffectiveProxy = $ProxyUrl
+}
+elseif ($agentProxy) {
+    $script:EffectiveProxy = $agentProxy
+}
+elseif ($envProxy -and (Test-IsValidProxyUri $envProxy)) {
+    $script:EffectiveProxy = $envProxy
+}
+elseif ($script:PreOnboarding -and $script:WinHttpProxy -and (Test-IsValidProxyUri "http://$($script:WinHttpProxy)")) {
+    # Pre-onboarding: no agent proxy, fallback to WinHTTP if configured
+    $whUri = if ($script:WinHttpProxy -match '^https?://') { $script:WinHttpProxy } else { "http://$($script:WinHttpProxy)" }
+    if (Test-IsValidProxyUri $whUri) { $script:EffectiveProxy = $whUri }
+}
+
+# --- Upstream proxy (Gateway mode) ---
+$upstreamProxy = $null
+if ($script:AgentJson) {
+    $upstreamProxy = if ($script:AgentJson.PSObject.Properties['upstreamProxy']) { $script:AgentJson.upstreamProxy }
+                     elseif ($script:AgentJson.PSObject.Properties['upstreamproxy']) { $script:AgentJson.upstreamproxy }
+                     else { $null }
+}
+
+# --- Display (pipe-delimited like azcmagent check) ---
+$pFmt = "  {0,-18} | {1,-35} | {2,-22}"
+Write-Host ($pFmt -f 'Source', 'Proxy', 'Used By') -ForegroundColor Cyan
+Write-Host ("  {0,-18}-+-{1,-35}-+-{2,-22}" -f ('-' * 18), ('-' * 35), ('-' * 22)) -ForegroundColor DarkGray
+
+$agentProxyLabel = if ($script:PreOnboarding) { 'N/A (not installed)' } elseif ($agentProxy) { $agentProxy } else { '(not set)' }
+$rows = @(
+    , @('WinHTTP (OS)',  $(if ($script:WinHttpProxy) { $script:WinHttpProxy } else { 'Direct' }),  'SCHANNEL/OCSP/CRL')
+    , @('azcmagent',    $agentProxyLabel,                                                          'Arc Agent')
+    , @('HTTPS_PROXY',  $(if ($envProxy) { $envProxy } else { '(not set)' }),                       'Extensions')
+)
+if ($upstreamProxy) {
+    $rows += , @('Upstream Proxy', $upstreamProxy, 'Gateway chain')
+}
+foreach ($r in $rows) {
+    $c = if ($r[1] -match 'not set|Direct|N/A') { 'DarkGray' } else { 'White' }
+    Write-Host ($pFmt -f $r[0], $r[1], $r[2]) -ForegroundColor $c
+}
+if ($script:EffectiveProxy) {
+    Write-Host ''
+    Write-Status 'Effective proxy' $script:EffectiveProxy Green
+}
+
+# --- Gateway + proxy.bypass warning ---
+if ($Mode -eq 'Gateway' -and $agentBypass) {
+    Add-Issue -Sev 'WARN' -Cat 'Gateway' `
+        -Msg 'proxy.bypass is configured but NOT supported in Gateway mode' `
+        -Fix 'Run: azcmagent config clear proxy.bypass'
+}
+
+# Neutralize .NET DefaultWebProxy for PS 5.1 when no proxy
 if (-not $script:EffectiveProxy -and $PSVersionTable.PSVersion.Major -lt 6) {
     try { [System.Net.WebRequest]::DefaultWebProxy = $null } catch { }
 }
 
-if ($Mode -eq 'Auto') {
-    $Mode = Resolve-ArcMode
-}
-Write-Log "Selected mode: $Mode | Region: $Region" Info -NoCount
+Log "Region=$Region Mode=$Mode Proxy=$($script:EffectiveProxy) Gateway=$($script:GatewayUrl)" Info -NoCount
 
-# Reset stats: the test phase starts here (detection does not count)
-$script:Stats.OK   = 0
+# =========================================================================
+# 3. TLS VERSION CHECK
+# =========================================================================
+
+Write-Section 'TLS Validation'
+# Azure Arc requires TLS 1.2 or 1.3 ONLY.
+# Required cipher suites:
+#   TLS 1.3: TLS_AES_256_GCM_SHA384, TLS_AES_128_GCM_SHA256
+#   TLS 1.2: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+# SQL Arc endpoints (*.arcdataservices.com) require TLS 1.2/1.3 — Server 2012 (non-R2) NOT supported.
+# Ref: https://learn.microsoft.com/azure/azure-arc/servers/troubleshoot-networking#windows-tls-configuration-issues
+
+$tlsOk = $false
+try {
+    $osVer = [System.Environment]::OSVersion.Version
+    $osBuild = $osVer.Build
+    $osCaption = (Get-CimInstance Win32_OperatingSystem -ErrorAction SilentlyContinue).Caption
+    if (-not $osCaption) { $osCaption = "Windows $($osVer.Major).$($osVer.Minor) Build $osBuild" }
+    Write-Status 'OS' $osCaption DarkGray
+
+    # --- 1. SCHANNEL Registry Check ---
+    $schBase = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols'
+    $tls12Disabled = $false
+    $tls12Path = "$schBase\TLS 1.2\Client"
+    if (Test-Path $tls12Path) {
+        $enVal = (Get-ItemProperty -Path $tls12Path -Name 'Enabled' -EA SilentlyContinue).Enabled
+        $dbVal = (Get-ItemProperty -Path $tls12Path -Name 'DisabledByDefault' -EA SilentlyContinue).DisabledByDefault
+        if ($enVal -eq 0) { $tls12Disabled = $true }
+        if ($dbVal -eq 1 -and $enVal -ne 1) { $tls12Disabled = $true }
+    }
+
+    # TLS 1.3 support (Server 2022+ / Build 20348+)
+    $has13 = $false
+    $tls13Path = "$schBase\TLS 1.3\Client"
+    if (Test-Path $tls13Path) {
+        $en13 = (Get-ItemProperty -Path $tls13Path -Name 'Enabled' -EA SilentlyContinue).Enabled
+        if ($en13 -ne 0) { $has13 = $true }
+    }
+    if ($osVer.Major -ge 10 -and $osBuild -ge 20348) { $has13 = $true }
+
+    # OS era check
+    $isServer2012NonR2 = ($osVer.Major -eq 6 -and $osVer.Minor -eq 2)  # 6.2 = Server 2012 / Win8
+    $isModernOS = ($osVer.Major -gt 6) -or ($osVer.Major -eq 6 -and $osVer.Minor -ge 3)  # 6.3+ = 2012R2+
+
+    # --- 2. Real TLS 1.2 Handshake Test ---
+    $tlsHandshakeOk = $false
+    $negotiatedProto = ''
+    try {
+        # Force .NET to use TLS 1.2 for this test
+        $savedProto = [System.Net.ServicePointManager]::SecurityProtocol
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+        $testReq = [System.Net.HttpWebRequest]::Create('https://login.microsoftonline.com')
+        $testReq.Timeout = 10000
+        $testReq.Method = 'HEAD'
+        if ($script:EffectiveProxy) {
+            $testReq.Proxy = [System.Net.WebProxy]::new($script:EffectiveProxy)
+            $testReq.Proxy.UseDefaultCredentials = $true
+        } elseif ($PSVersionTable.PSVersion.Major -lt 6) {
+            $testReq.Proxy = $null
+        }
+        $testResp = $testReq.GetResponse()
+        $testResp.Close()
+        $tlsHandshakeOk = $true
+        $negotiatedProto = 'TLS 1.2'
+        [System.Net.ServicePointManager]::SecurityProtocol = $savedProto
+    }
+    catch {
+        try { [System.Net.ServicePointManager]::SecurityProtocol = $savedProto } catch { }
+        # If TLS 1.2 fails, the OS may not support it
+    }
+
+    # --- 3. Cipher Suite Check ---
+    $requiredCiphers12 = @(
+        'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
+        'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256'
+    )
+    $requiredCiphers13 = @(
+        'TLS_AES_256_GCM_SHA384'
+        'TLS_AES_128_GCM_SHA256'
+    )
+    $cipherOk = $true
+    $missingCiphers = @()
+    try {
+        $sysCiphers = (Get-TlsCipherSuite -ErrorAction SilentlyContinue).Name
+        if ($sysCiphers) {
+            foreach ($rc in $requiredCiphers12) {
+                if ($sysCiphers -notcontains $rc) { $missingCiphers += $rc; $cipherOk = $false }
+            }
+        }
+        # Get-TlsCipherSuite may not exist on older OS (Server 2012/2012R2)
+    }
+    catch {
+        # Get-TlsCipherSuite not available — skip cipher check (older OS)
+        $cipherOk = $true
+    }
+
+    # --- 4. .NET Strong Crypto ---
+    $strongCrypto = $false
+    $regPath64 = 'HKLM:\SOFTWARE\Microsoft\.NETFramework\v4.0.30319'
+    $regPath32 = 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\.NETFramework\v4.0.30319'
+    foreach ($rp in @($regPath64, $regPath32)) {
+        if (Test-Path $rp) {
+            $sc = (Get-ItemProperty -Path $rp -Name 'SchUseStrongCrypto' -EA SilentlyContinue).SchUseStrongCrypto
+            if ($sc -eq 1) { $strongCrypto = $true }
+        }
+    }
+
+    # --- Display Results ---
+    if ($tls12Disabled) {
+        Write-Status 'SCHANNEL TLS 1.2' 'DISABLED in registry' Red
+        Add-Issue -Sev 'CRITICAL' -Cat 'TLS' `
+            -Msg 'TLS 1.2 is disabled in SCHANNEL registry. Azure Arc requires TLS 1.2+.' `
+            -Fix 'https://learn.microsoft.com/azure/azure-arc/servers/troubleshoot-networking#windows-tls-configuration-issues'
+    }
+    elseif ($tlsHandshakeOk) {
+        $tlsLabel = if ($has13) { 'TLS 1.2 + 1.3' } else { 'TLS 1.2' }
+        Write-Status 'TLS Handshake' "$tlsLabel verified (live test passed)" Green
+        $tlsOk = $true
+    }
+    elseif ($isModernOS) {
+        Write-Status 'TLS SCHANNEL' 'TLS 1.2 enabled (OS default, handshake test failed)' Yellow
+        $tlsOk = $true
+    }
+    else {
+        Write-Status 'TLS' 'Could not verify TLS 1.2 - check SCHANNEL config' Yellow
+        Add-Issue -Sev 'HIGH' -Cat 'TLS' `
+            -Msg 'Cannot verify TLS 1.2 support. Azure Arc requires TLS 1.2+.' `
+            -Fix 'https://learn.microsoft.com/azure/azure-arc/servers/troubleshoot-networking#windows-tls-configuration-issues'
+    }
+
+    # Cipher suites
+    if (-not $cipherOk -and $missingCiphers.Count -gt 0) {
+        Write-Status 'Cipher Suites' "MISSING: $($missingCiphers -join ', ')" Red
+        Add-Issue -Sev 'HIGH' -Cat 'TLS Ciphers' `
+            -Msg "Required cipher suites missing: $($missingCiphers -join ', ')" `
+            -Fix 'Enable GCM cipher suites via Group Policy or PowerShell Enable-TlsCipherSuite'
+    }
+    elseif ($missingCiphers.Count -eq 0 -and $cipherOk) {
+        Write-Status 'Cipher Suites' 'Required GCM suites present' Green
+    }
+
+    # .NET StrongCrypto
+    if ($strongCrypto) {
+        Write-Status '.NET StrongCrypto' 'Enabled' Green
+    }
+    else {
+        Write-Status '.NET StrongCrypto' 'NOT set (recommended for PS 5.1 / .NET apps)' Yellow
+    }
+
+    # Server 2012 (non-R2) + SQL Arc warning
+    if ($isServer2012NonR2 -and ($script:InstalledExts -contains 'SQL' -or $CheckIncludeAll)) {
+        Write-Status 'SQL Arc TLS' 'Server 2012 (non-R2) NOT supported for SQL Arc telemetry' Red
+        Add-Issue -Sev 'HIGH' -Cat 'SQL TLS' `
+            -Msg 'Windows Server 2012 (non-R2) does not support TLS 1.2 for *.arcdataservices.com endpoints.' `
+            -Fix 'Upgrade to Server 2012 R2+ for SQL Server enabled by Azure Arc.'
+    }
+}
+catch {
+    Write-Status 'TLS' "Check error: $($_.Exception.Message)" Yellow
+    $tlsOk = $true
+}
+Log "TLS check: OK=$tlsOk handshake=$tlsHandshakeOk ciphers=$cipherOk strongCrypto=$strongCrypto" $(if ($tlsOk) { 'OK' } else { 'Fail' })
+
+# =========================================================================
+# 4. PKI/OCSP/CRL BYPASS VALIDATION
+# =========================================================================
+
+$pkiEndpoints = @(
+    'oneocsp.microsoft.com'       # OCSP primary
+    'crl.microsoft.com'           # CRL Microsoft root
+    'crl2.microsoft.com'          # CRL Microsoft intermediate
+    'crl3.digicert.com'           # CRL DigiCert
+    'crl4.digicert.com'           # CRL DigiCert alt
+    'ocsp.digicert.com'           # OCSP DigiCert
+    'ctldl.windowsupdate.com'     # Certificate Trust List
+    'www.microsoft.com'           # PKI AIA chain
+    'caissuers.microsoft.com'     # CA Issuers (AIA)
+    'login.live.com'              # Live ID cert validation
+)
+
+$pkiWildcardCovers = @{
+    '.microsoft.com'      = @('oneocsp.microsoft.com', 'crl.microsoft.com', 'crl2.microsoft.com',
+                              'www.microsoft.com', 'caissuers.microsoft.com')
+    '.digicert.com'       = @('crl3.digicert.com', 'crl4.digicert.com', 'ocsp.digicert.com')
+    '.live.com'           = @('login.live.com')
+    '.ocsp.microsoft.com' = @('oneocsp.microsoft.com')
+    '.ocsp.digicert.com'  = @('ocsp.digicert.com')
+}
+
+function Test-PkiBypassCoverage {
+    if (-not $script:WinHttpProxy) { return @() }
+
+    $byList = @()
+    if ($script:WinHttpBypass) {
+        # WinHTTP uses *.domain.com format; normalize to .domain.com for matching
+        $byList += $script:WinHttpBypass -split ';' |
+            ForEach-Object { $_.Trim().ToLower() } | Where-Object { $_ } |
+            ForEach-Object { if ($_ -match '^\*\.([a-z])') { $_.Substring(1) } else { $_ } }
+    }
+    if ($envNoProxy) {
+        $byList += $envNoProxy -split ',' |
+            ForEach-Object { $_.Trim().ToLower() } | Where-Object { $_ }
+    }
+    if ($byList.Count -eq 0) { return $pkiEndpoints }
+
+    $covered = [System.Collections.ArrayList]::new()
+    foreach ($wc in $pkiWildcardCovers.Keys) {
+        if ($byList -contains $wc.ToLower()) {
+            foreach ($ep in $pkiWildcardCovers[$wc]) {
+                if ($covered -notcontains $ep.ToLower()) { [void]$covered.Add($ep.ToLower()) }
+            }
+        }
+    }
+
+    $uncovered = @()
+    foreach ($ep in $pkiEndpoints) {
+        $lo = $ep.ToLower()
+        if ($byList -contains $lo) { continue }
+        if ($covered -contains $lo) { continue }
+        $matched = $false
+        foreach ($be in $byList) {
+            if ($be.StartsWith('.') -and $lo.EndsWith($be)) { $matched = $true; break }
+        }
+        if (-not $matched) { $uncovered += $ep }
+    }
+    return $uncovered
+}
+
+if (-not $SkipPKI -and $script:WinHttpProxy) {
+    Write-Section 'PKI/OCSP/CRL Proxy Bypass'
+    $uncPki = Test-PkiBypassCoverage
+    if ($uncPki.Count -eq 0) {
+        Write-Host '  All PKI endpoints covered by bypass list' -ForegroundColor Green
+    }
+    else {
+        Write-Host '  PKI endpoints MISSING from proxy bypass (TLS will fail):' -ForegroundColor Red
+        $bFmt = "    {0,-9} | {1}"
+        Write-Host ($bFmt -f 'Status', 'Endpoint') -ForegroundColor Gray
+        Write-Host ("    {0,-9}-+-{1}" -f ('-' * 9), ('-' * 40)) -ForegroundColor DarkGray
+        foreach ($ep in $uncPki) {
+            Write-Host ($bFmt -f 'MISSING', $ep) -ForegroundColor Red
+            Log "PKI bypass MISSING: $ep" Fail
+        }
+        Add-Issue -Sev 'CRITICAL' -Cat 'PKI Bypass' `
+            -Msg "$($uncPki.Count) PKI endpoint(s) not in proxy bypass" `
+            -Fix "Add to GPO NO_PROXY: $($uncPki -join ',')"
+    }
+}
+
+# =========================================================================
+# 5. ENDPOINT DEFINITIONS
+# =========================================================================
+
+# Reset stats for test phase
+$script:Stats.OK = 0
 $script:Stats.Fail = 0
 $script:Stats.Warn = 0
 
-# ---------------------------------------------------------------------------
-# Endpoints — organized by functional group
-# ---------------------------------------------------------------------------
-
-# Endpoints that CAN resolve to a private IP via Azure Private Link Scope.
-# Everything NOT in this list is always public — do not raise a WARN in Private mode.
-$canBePrivateEndpoints = @(
+# Endpoints eligible for Private Link resolution
+$canBePrivate = [System.Collections.ArrayList]@(
     'gbl.his.arc.azure.com'
     'agentserviceapi.guestconfiguration.azure.com'
     'dc.services.visualstudio.com'
     'global.handler.control.monitor.azure.com'
 )
 
-# Core Arc (required) — aligned with the Connected Machine agent network-requirements.
-# Doc: https://learn.microsoft.com/azure/azure-arc/servers/network-requirements
-$coreEndpoints = @(
-    # AAD / Identity (always; Public)
+# --- Core endpoints (always tested) ---
+$coreEps = [System.Collections.ArrayList]@(
     'login.windows.net'
     'login.microsoftonline.com'
+    "$Region.login.microsoft.com"
     'pas.windows.net'
-
-    # ARM (connect/disconnect; Public unless Resource Management Private Link)
     'management.azure.com'
-
-    # Arc HIMDS (always; Private via PLS)
     'gbl.his.arc.azure.com'
-
-    # Guest Configuration / extension management (always; Private via PLS)
     'agentserviceapi.guestconfiguration.azure.com'
-
-    # Agent install/update (Public)
     'packages.microsoft.com'
     'download.microsoft.com'
-
-    # Telemetry (optional; NOT used on agents 1.24+; Public)
     'dc.services.visualstudio.com'
 )
 
-# SQL endpoints (optional via -IncludeSQL) — Arc-enabled SQL Server.
-# Doc: network-requirements + sql/.../data-collection. All Public; TLS 1.2/1.3.
-$sqlEndpoints = @()
-if ($IncludeSQL) {
-    $sqlEndpoints = @(
-        # Data processing service + telemetry (extensions from Mar/2024 onward)
+# GNS global (Public/Gateway modes)
+if ($Mode -in 'Public', 'Gateway') {
+    [void]$coreEps.Add('guestnotificationservice.azure.com')
+}
+
+# Gateway URL
+if ($script:GatewayUrl) {
+    try {
+        $gwFqdn = ([System.Uri]$script:GatewayUrl).Host
+        if ($gwFqdn) { [void]$coreEps.Add($gwFqdn) }
+    }
+    catch {
+        $gwFqdn = $script:GatewayUrl -replace 'https?://', '' -replace '/.*', ''
+        if ($gwFqdn) { [void]$coreEps.Add($gwFqdn) }
+    }
+}
+
+# --- Extension endpoints (auto-detected) ---
+$extEps = @{}
+
+# SQL Server
+if ($script:InstalledExts -contains 'SQL' -or $CheckIncludeAll) {
+    $extEps['SQL'] = @(
         "dataprocessingservice.$Region.arcdataservices.com"
         "telemetry.$Region.arcdataservices.com"
-        # Legacy: used by extensions until Feb 13, 2024
         "san-af-$Region-prod.azurewebsites.net"
-        # Arc SQL Microsoft Entra authentication (Public). Only needed when using
-        # Entra auth; NOT a core agent endpoint. Reachable directly, but may be
-        # blocked on a split-tunnel proxy -> DNS/TCP only (no HTTP probe).
         'graph.microsoft.com'
     )
 }
 
-# AMA endpoints (optional via -IncludeAMA) — Azure Monitor Agent.
-# Doc: azure-monitor-agent-network-configuration. The <workspace-id>.ods and
-# <dce>.ingest.monitor endpoints require specific IDs -> not generically testable.
-$amaEndpoints = @()
-if ($IncludeAMA) {
-    $amaEndpoints = @(
-        'global.handler.control.monitor.azure.com'   # control service
-        'global.prod.microsoftmetrics.com'           # metrics service
-        "$Region.handler.control.monitor.azure.com"  # regional DCRs
-        "$Region.monitoring.azure.com"               # custom metrics (optional)
+# Defender for SQL (separate from MDE)
+if ($script:InstalledExts -contains 'DSQL' -or $CheckIncludeAll) {
+    if (-not $extEps.ContainsKey('SQL')) { $extEps['SQL'] = @() }
+    $extEps['SQL'] += @("defender-for-databases.$Region.arcdataservices.com")
+}
+
+# AMA (Azure Monitor Agent) + Dependency Agent
+if ($script:InstalledExts -contains 'AMA' -or $script:InstalledExts -contains 'DA' -or $CheckIncludeAll) {
+    $extEps['AMA'] = @(
+        'global.handler.control.monitor.azure.com'
+        'global.prod.microsoftmetrics.com'
+        "$Region.handler.control.monitor.azure.com"
+        "$Region.monitoring.azure.com"
     )
 }
 
-# MDE endpoints (optional via -IncludeMDE)
-$mdeEndpoints = @()
-if ($IncludeMDE) {
-    $mdeEndpoints = @(
+# MDE (Microsoft Defender for Endpoint)
+if ($script:InstalledExts -contains 'MDE' -or $CheckIncludeAll) {
+    $extEps['MDE'] = @(
         'unitedstates.x.cp.wd.microsoft.com'
         'us-v20.events.data.microsoft.com'
+        'winatp-gw-cus3.microsoft.com'
     )
 }
 
-# WAC endpoints (optional via -IncludeWAC)
-# Note: 'pas.windows.net' is already in $coreEndpoints and $endpointGroupMap
-# preserves Core precedence, avoiding duplication in the summary.
-$wacEndpoints = @()
-if ($IncludeWAC) {
-    $wacEndpoints = @(
-        "$Region.service.waconazure.com"
+# WAC (Windows Admin Center)
+if ($script:InstalledExts -contains 'WAC' -or $CheckIncludeAll) {
+    $extEps['WAC'] = @("$Region.service.waconazure.com")
+}
+
+# Key Vault extension
+if ($script:InstalledExts -contains 'KV' -or $CheckIncludeAll) {
+    $extEps['KV'] = @('*.vault.azure.net')
+}
+
+# Hybrid Runbook Worker
+if ($script:InstalledExts -contains 'HRW' -or $CheckIncludeAll) {
+    $extEps['HRW'] = @(
+        '*.azure-automation.net'
+        '*.agentsvc.azure-automation.net'
     )
 }
 
-# Endpoints that respond to HTTP (L7 validation — 200/400/401/403/404 = reachable).
-# Does NOT include graph.microsoft.com: it is the Arc SQL Entra auth endpoint (optional)
-# and is often blocked on a split-tunnel proxy; the official Arc SQL connectivity
-# test itself validates only DPS + telemetry.
-$httpProbeEndpoints = @(
-    'login.windows.net'
-    'login.microsoftonline.com'
-    'management.azure.com'
-)
-if ($IncludeSQL) {
-    # Aligned with the official Arc SQL test: DPS expects 200; telemetry expects 401
-    # (both treated as reachable here).
-    $httpProbeEndpoints += "dataprocessingservice.$Region.arcdataservices.com"
-    $httpProbeEndpoints += "telemetry.$Region.arcdataservices.com"
+# Update Manager
+if ($script:InstalledExts -contains 'UM' -or $CheckIncludeAll) {
+    $extEps['UM'] = @("$Region.monitoring.azure.com")
 }
 
-# Maps a group per endpoint for the summary. Core has PRECEDENCE: if an endpoint
-# appears in more than one group (e.g. pas.windows.net in Core and WAC), we keep 'Core'.
-$endpointGroupMap = @{}
-foreach ($ep in $coreEndpoints) { $endpointGroupMap[$ep] = 'Core' }
-foreach ($ep in $sqlEndpoints)  { if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = 'SQL' } }
-foreach ($ep in $amaEndpoints)  { if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = 'AMA' } }
-foreach ($ep in $mdeEndpoints)  { if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = 'MDE' } }
-foreach ($ep in $wacEndpoints)  { if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = 'WAC' } }
+# Guest Attestation
+if ($script:InstalledExts -contains 'GA' -or $CheckIncludeAll) {
+    $extEps['GA'] = @('*.attest.azure.net')
+}
 
-# Dynamic allowlist (Public mode only; under PLS traffic goes via PE)
-$dynamicEndpoints = @()
-if ($Mode -eq 'Public') {
+# -SkipExtensions overrides -CheckIncludeAll (user explicitly asked to skip)
+if ($SkipExtensions -and $extEps.Count -gt 0) {
+    $extEps = @{}
+    Log 'Extension endpoints skipped (-SkipExtensions)' Info -NoCount
+}
+
+# =========================================================================
+# 6. DISCOVER REGIONAL ENDPOINTS (azcmagent check)
+# =========================================================================
+# Regional Arc endpoints use unpredictable abbreviations (e.g. eus2, brs, ncus).
+# Instead of guessing, we parse 'azcmagent check' output to discover the actual
+# endpoints the agent uses.
+
+Write-Section 'Endpoint Discovery (azcmagent check)'
+
+$script:AzcmagentCheckExit = $null
+$discoveredEps = @()
+
+if ($azcm) {
+    $checkArgs = @('check', '--location', $Region, '--cloud', 'AzureCloud')
+    if ($CheckIncludeAll) {
+        $checkArgs += @('--extensions', 'all', '--include-all')
+    }
+    elseif ($script:InstalledExts -contains 'SQL') {
+        $checkArgs += @('--extensions', 'sql')
+    }
+    if ($Mode -eq 'Private') { $checkArgs += '--enable-pls-check' }
+
+    Write-Host "  azcmagent $($checkArgs -join ' ')" -ForegroundColor Gray
     try {
-        Write-Log 'Fetching dynamic endpoints from guestnotificationservice...' Info -NoCount
-        $uri  = "https://guestnotificationservice.azure.com/urls/allowlist?api-version=2020-01-01&location=$Region"
-        $resp = Invoke-WebRequestSafe -Uri $uri
-        $dynamicEndpoints = @($resp.Content | ConvertFrom-Json) | Where-Object { $_ }
-        if ($dynamicEndpoints.Count -gt 0) {
-            $totalGNS = $dynamicEndpoints.Count
+        $out = & $azcm @checkArgs 2>&1
+        $script:AzcmagentCheckExit = $LASTEXITCODE
+        Save-Log
+        Add-Content -Path $LogFilePath -Value $out
 
-            # Filter: keep only the region's primary endpoints.
-            # Primary namespaces contain '<N>p-' (e.g. 1p-, 2p-), secondary contain '<N>s-'.
-            # Extract cluster IDs from the primaries and filter children by them.
-            $primaryClusterIds = [System.Collections.ArrayList]::new()
-            foreach ($dep in $dynamicEndpoints) {
-                if ($dep -match '^azgn-.+\dp-.+?-(\w+)\.servicebus') {
-                    [void]$primaryClusterIds.Add($Matches[1])
+        # Parse pipe-delimited output to extract endpoint FQDNs
+        foreach ($line in $out) {
+            $s = "$line".Trim()
+            if ($s -match '\|\s*https?://([^\s|/]+)') {
+                $fqdn = $Matches[1]
+                if ($fqdn -and $fqdn -notmatch '^(Use Case|Endpoint)') {
+                    $discoveredEps += $fqdn
                 }
             }
+        }
+        $discoveredEps = $discoveredEps | Select-Object -Unique
 
-            if ($primaryClusterIds.Count -gt 0) {
-                $filteredGNS = [System.Collections.ArrayList]::new()
-                foreach ($dep in $dynamicEndpoints) {
-                    if ($dep -match '^azgn-') {
-                        [void]$filteredGNS.Add($dep)   # always keep namespace-level
-                    }
-                    else {
-                        foreach ($cid in $primaryClusterIds) {
-                            if ($dep -like "*$cid*") {
-                                [void]$filteredGNS.Add($dep)
-                                break
-                            }
-                        }
-                    }
-                }
-                $skipped = $totalGNS - $filteredGNS.Count
-                $dynamicEndpoints = @($filteredGNS)
-                if ($skipped -gt 0) {
-                    Write-Log "Dynamic endpoints obtained: $totalGNS total, $($filteredGNS.Count) primary ($skipped secondary filtered out)" OK
-                }
-                else {
-                    Write-Log "Dynamic endpoints obtained: $totalGNS endpoint(s)" OK
-                }
-            }
-            else {
-                Write-Log "Dynamic endpoints obtained: $totalGNS endpoint(s)" OK
-            }
-
-            foreach ($dep in $dynamicEndpoints) {
-                $endpointGroupMap[$dep] = 'GNS'
-            }
+        if ($script:AzcmagentCheckExit -eq 0) {
+            Write-Host "  PASSED - discovered $($discoveredEps.Count) endpoints" -ForegroundColor Green
+        }
+        else {
+            Write-Host "  FAILED (exit $($script:AzcmagentCheckExit)) - discovered $($discoveredEps.Count) endpoints" -ForegroundColor Red
+            Add-Issue -Sev 'HIGH' -Cat 'Agent Check' `
+                -Msg "azcmagent check failed (exit $($script:AzcmagentCheckExit))" `
+                -Fix 'Review azcmagent check output in log file'
         }
     }
     catch {
-        # The dynamic allowlist is AUXILIARY: its unavailability must not break the
-        # exit code (WARN, not FAIL). Common when forcing -Mode Public on a host that,
-        # in practice, routes GNS via Private Link / firewall.
-        Write-Log "Failed to obtain dynamic endpoints (auxiliary allowlist): $($_.Exception.Message)" Warn
+        Write-Host "  ERROR: $($_.Exception.Message)" -ForegroundColor Red
     }
 }
 else {
-    Write-Log 'Private mode: skipping public allowlist query.' Info -NoCount
-}
+    Write-Host '  azcmagent not found - using DNS-based regional endpoint discovery' -ForegroundColor Yellow
 
-$allEndpoints = @(
-    $coreEndpoints + $sqlEndpoints + $amaEndpoints + $mdeEndpoints +
-    $wacEndpoints + $dynamicEndpoints |
-    Where-Object { $_ } |
-    Select-Object -Unique
-)
-
-Write-Log "Total endpoints to test: $($allEndpoints.Count)" Info -NoCount
-[void]$script:LogBuffer.Add('')
-
-# ---------------------------------------------------------------------------
-# Tests: DNS + TCP/443 (consistency check against the detected mode)
-# ---------------------------------------------------------------------------
-foreach ($ep in $allEndpoints) {
-    $ep = $ep.Trim()
-    if (-not $ep) { continue }
-
-    Write-Verbose "Testing: $ep"
-
-    [void]$script:LogBuffer.Add('-' * 60)
-    $group = if ($endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] } else { 'Dyn' }
-    Add-Result -Endpoint $ep -Group $group
-
-    # DNS (with 1 retry on a transient failure, e.g. SERVFAIL when resolving many names)
-    $dns = $null
-    $dnsErr = $null
-    foreach ($attempt in 1..2) {
-        try { $dns = Resolve-DnsName -Name $ep -ErrorAction Stop; $dnsErr = $null; break }
-        catch { $dnsErr = $_; if ($attempt -lt 2) { Start-Sleep -Milliseconds 300 } }
+    # --- Regional endpoint fallback (no agent) ---
+    # his.arc.azure.com uses unpredictable abbreviations per region.
+    # We try a known map + DNS probing to discover the correct FQDN.
+    $regionAbbrevMap = @{
+        'eastus'='eus'; 'eastus2'='eus2'; 'westus'='wus'; 'westus2'='wus2'; 'westus3'='wus3'
+        'centralus'='cus'; 'northcentralus'='ncus'; 'southcentralus'='scus'; 'westcentralus'='wcus'
+        'canadacentral'='cac'; 'canadaeast'='cae'
+        'brazilsouth'='brs'; 'brazilsoutheast'='brse'
+        'northeurope'='neu'; 'westeurope'='weu'
+        'uksouth'='uks'; 'ukwest'='ukw'
+        'francecentral'='frc'; 'francesouth'='frs'
+        'germanywestcentral'='gwc'; 'switzerlandnorth'='szn'; 'switzerlandwest'='szw'
+        'norwayeast'='noe'; 'norwaywest'='now'; 'swedencentral'='sec'
+        'australiaeast'='aue'; 'australiasoutheast'='ause'
+        'eastasia'='ea'; 'southeastasia'='sea'
+        'japaneast'='jpe'; 'japanwest'='jpw'
+        'koreacentral'='krc'; 'koreasouth'='krs'
+        'centralindia'='inc'; 'southindia'='ins'; 'westindia'='inw'
+        'southafricanorth'='san'; 'southafricawest'='saw'
+        'uaenorth'='uan'; 'uaecentral'='uac'
+        'qatarcentral'='qac'; 'polandcentral'='plc'; 'italynorth'='itn'
     }
-    if ($dnsErr) {
-        # Dynamic endpoints (GNS) are AUXILIARY: a DNS failure on them becomes WARN
-        # (not FAIL), because a transient SERVFAIL when resolving dozens of
-        # 'servicebus' names must not break the exit code. Other groups stay FAIL.
-        $existingD = $script:Results | Where-Object { $_.Endpoint -eq $ep }
-        if ($group -eq 'GNS') {
-            Write-Log "DNS WARN $ep - $($dnsErr.Exception.Message) (dynamic/auxiliary endpoint)" Warn
-            if ($existingD) { $existingD.DNS = 'WARN' }
+
+    # Try HIS endpoint: abbreviation first, then full name
+    $hisCandidates = @()
+    $rLower = $Region.ToLower()
+    if ($regionAbbrevMap.ContainsKey($rLower)) {
+        $hisCandidates += "$($regionAbbrevMap[$rLower]).his.arc.azure.com"
+    }
+    $hisCandidates += "$Region.his.arc.azure.com"
+
+    foreach ($hc in $hisCandidates) {
+        try {
+            $null = Resolve-DnsName -Name $hc -ErrorAction Stop
+            $discoveredEps += $hc
+            Write-Host "    Discovered: $hc" -ForegroundColor Green
+            break
         }
-        else {
-            Write-Log "DNS FAIL $ep - $($dnsErr.Exception.Message)" Fail
-            if ($existingD) { $existingD.DNS = 'FAIL' }
-        }
-        continue
+        catch { }
     }
 
-    # Prefer IPv4 (A record): Azure Private Link and most Arc endpoints are resolved
-    # by A record. A public AAAA (IPv6) may coexist with the private A; if chosen, it
-    # causes an incorrect PUBLIC classification and tests over a possibly
-    # nonexistent/unrouted IPv6 path.
-    $rec = $dns | Where-Object { $_.Type -eq 'A' -and $_.IPAddress } | Select-Object -First 1
-    if (-not $rec) { $rec = $dns | Where-Object IPAddress | Select-Object -First 1 }
-    $ip   = $rec.IPAddress
-    $kind = if (Test-IsPrivateIp -Ip $ip) { 'PRIVATE' } else { 'PUBLIC' }
-
-    # Update result
-    $existing = $script:Results | Where-Object { $_.Endpoint -eq $ep }
-    if ($existing) { $existing.IP = $ip; $existing.Type = $kind }
-
-    # DNS vs mode mismatch alert
-    # Only endpoints in $canBePrivateEndpoints should resolve to a private IP.
-    # All others (AAD, ARM, CDN, SQL, AMA, MDE, WAC, GNS) are always public.
-    $canBePrivate = $canBePrivateEndpoints -contains $ep
-    $mismatch = $false
-    if ($Mode -eq 'Private' -and $kind -eq 'PUBLIC' -and $canBePrivate) {
-        $mismatch = $true
-    }
-    elseif ($Mode -eq 'Public' -and $kind -eq 'PRIVATE') {
-        $mismatch = $true
-    }
-    if ($mismatch) {
-        Write-Log "DNS WARN $ep -> $ip [$kind] (expected the opposite for $Mode mode)" Warn
-        $existing2 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
-        if ($existing2) { $existing2.DNS = 'WARN' }
-    }
-    else {
-        Write-Log "DNS OK   $ep -> $ip [$kind]" OK
-        $existing2 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
-        if ($existing2) { $existing2.DNS = 'OK' }
-    }
-
-    # TCP/443 (TcpClient with timeout — much faster than Test-NetConnection)
-    $tcpSw = [System.Diagnostics.Stopwatch]::StartNew()
-    $tcpOk = Test-TcpPort -ComputerName $ep -Port 443 -TimeoutMs 5000
-    $tcpSw.Stop()
-    $latencyMs = [math]::Round($tcpSw.Elapsed.TotalMilliseconds, 0)
-
-    $existing3 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
-    if ($tcpOk) {
-        Write-Log "TCP OK   ${ep}:443 (${latencyMs}ms)" OK
-        if ($existing3) { $existing3.TCP = 'OK'; $existing3.Latency = "${latencyMs}ms" }
-    }
-    else {
-        Write-Log "TCP FAIL ${ep}:443 (timeout/refused)" Fail
-        if ($existing3) { $existing3.TCP = 'FAIL'; $existing3.Latency = 'timeout' }
-    }
-}
-
-# ---------------------------------------------------------------------------
-# HTTP tests (401/403/400 are treated as success: endpoint requires auth)
-# Detects azcmagent proxy.bypass to skip HTTP tests on bypassed endpoints
-# ---------------------------------------------------------------------------
-$proxyBypassCategories = @()
-$azcmPath = Get-AzcmagentPath
-if ($azcmPath -and $script:EffectiveProxy) {
+    # GuestConfiguration always uses full region name with -gas suffix
+    $gcCandidate = "$Region-gas.guestconfiguration.azure.com"
     try {
-        $bypassRaw = & $azcmPath config get proxy.bypass 2>$null
-        $bypassRawStr = if ($bypassRaw) { ($bypassRaw | Out-String).Trim() } else { '' }
-        if ($bypassRawStr) {
-            $bypassClean = $bypassRawStr.Trim('[', ']')
-            $proxyBypassCategories = $bypassClean -split ',' |
-                ForEach-Object { $_.Trim() } |
-                Where-Object { $_ }
+        $null = Resolve-DnsName -Name $gcCandidate -ErrorAction Stop
+        $discoveredEps += $gcCandidate
+        Write-Host "    Discovered: $gcCandidate" -ForegroundColor Green
+    }
+    catch { }
+
+    if ($discoveredEps.Count -gt 0) {
+        Write-Host "  Discovered $($discoveredEps.Count) regional endpoint(s) via DNS" -ForegroundColor Green
+    }
+    else {
+        Write-Host '  No regional endpoints discovered (verify -Region parameter)' -ForegroundColor Yellow
+        Add-Issue -Sev 'WARN' -Cat 'Discovery' `
+            -Msg "Could not discover regional endpoints for region '$Region'" `
+            -Fix 'Verify -Region parameter or install azcmagent first'
+    }
+}
+
+# Merge discovered endpoints into core list (avoid duplicates)
+foreach ($dep in $discoveredEps) {
+    if ($coreEps -notcontains $dep) { [void]$coreEps.Add($dep) }
+    # Mark PLS-eligible patterns
+    if ($dep -match 'his\.arc\.azure\.com|guestconfiguration\.azure\.com') {
+        if ($canBePrivate -notcontains $dep) { [void]$canBePrivate.Add($dep) }
+    }
+}
+
+# --- Build final endpoint group map ---
+$endpointGroupMap = @{}
+foreach ($ep in $coreEps) { $endpointGroupMap[$ep] = 'Core' }
+foreach ($grp in $extEps.Keys) {
+    foreach ($ep in $extEps[$grp]) {
+        if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = $grp }
+    }
+}
+if (-not $SkipPKI) {
+    foreach ($ep in $pkiEndpoints) {
+        if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = 'PKI' }
+    }
+}
+
+# --- Dynamic GNS allowlist (Public mode only) ---
+$dynamicEps = @()
+if ($Mode -eq 'Public') {
+    try {
+        $uri  = "https://guestnotificationservice.azure.com/urls/allowlist?api-version=2020-01-01&location=$Region"
+        $resp = Invoke-HttpSafe -Uri $uri
+        $dynamicEps = @($resp.Content | ConvertFrom-Json) | Where-Object { $_ }
+        if ($dynamicEps.Count -gt 0) {
+            # Filter to primary namespaces only
+            $pids = [System.Collections.ArrayList]::new()
+            foreach ($d in $dynamicEps) {
+                if ($d -match '^azgn-.+\dp-.+?-(\w+)\.servicebus') { [void]$pids.Add($Matches[1]) }
+            }
+            if ($pids.Count -gt 0) {
+                $filtered = [System.Collections.ArrayList]::new()
+                foreach ($d in $dynamicEps) {
+                    if ($d -match '^azgn-') { [void]$filtered.Add($d) }
+                    else {
+                        foreach ($cid in $pids) {
+                            if ($d -like "*$cid*") { [void]$filtered.Add($d); break }
+                        }
+                    }
+                }
+                $dynamicEps = @($filtered)
+            }
+            foreach ($d in $dynamicEps) { $endpointGroupMap[$d] = 'GNS' }
+        }
+    }
+    catch {
+        Log "GNS dynamic allowlist failed: $($_.Exception.Message)" Warn
+    }
+}
+
+# --- Build combined testable list ---
+$allTestable = @()
+foreach ($ep in $coreEps) { $allTestable += $ep }
+foreach ($grp in $extEps.Keys) {
+    foreach ($ep in $extEps[$grp]) { $allTestable += $ep }
+}
+$allTestable += $dynamicEps
+if (-not $SkipPKI) { $allTestable += $pkiEndpoints }
+
+# Separate wildcards (informational, not testable) from concrete FQDNs
+$wildcardEps = @($allTestable | Where-Object { $_ -match '^\*\.' } | Select-Object -Unique)
+$allTestable = @($allTestable | Where-Object { $_ -notmatch '^\*\.' } | Where-Object { $_ } | Select-Object -Unique)
+
+# --- HTTP probe endpoints ---
+$httpProbeEps = @('login.windows.net', 'login.microsoftonline.com', 'management.azure.com')
+if ($extEps.ContainsKey('SQL')) {
+    $httpProbeEps += "dataprocessingservice.$Region.arcdataservices.com"
+    $httpProbeEps += "telemetry.$Region.arcdataservices.com"
+}
+
+# --- Agent proxy.bypass => skip HTTP for bypassed endpoints ---
+$httpBypassedEps = [System.Collections.ArrayList]::new()
+if ($azcm -and $script:EffectiveProxy) {
+    $bypassCats = @()
+    try {
+        $bRaw = (& $azcm config get proxy.bypass 2>$null | Out-String).Trim()
+        if ($bRaw) {
+            $bypassCats = $bRaw.Trim('[', ']') -split ',' |
+                ForEach-Object { $_.Trim() } | Where-Object { $_ }
         }
     }
     catch { }
-}
 
-# Map of bypass categories -> affected endpoints (per the official doc:
-# https://learn.microsoft.com/azure/azure-arc/servers/manage-agent-proxy-settings).
-# IMPORTANT: 'graph.microsoft.com' is NOT covered by any bypass — the agent
-# uses the proxy for it; therefore it must NOT be skipped in the HTTP tests.
-# 'ArcData' is valid from agent 1.36 onward; in earlier versions the
-# arcdataservices endpoints fell under the 'Arc' category.
-$bypassCategoryEndpoints = @{
-    'AAD'     = @('login.windows.net', 'login.microsoftonline.com', 'pas.windows.net')
-    'ARM'     = @('management.azure.com')
-    'AMA'     = @(
-        'global.handler.control.monitor.azure.com'
-        "$Region.handler.control.monitor.azure.com"
-        'management.azure.com'
-        "$Region.monitoring.azure.com"
-    )
-    'Arc'     = @('gbl.his.arc.azure.com', 'agentserviceapi.guestconfiguration.azure.com')
-    'ArcData' = @(
-        "dataprocessingservice.$Region.arcdataservices.com"
-        "telemetry.$Region.arcdataservices.com"
-    )
-}
-
-$httpBypassedEndpoints = [System.Collections.ArrayList]::new()
-foreach ($cat in $proxyBypassCategories) {
-    if ($bypassCategoryEndpoints.ContainsKey($cat)) {
-        foreach ($bep in $bypassCategoryEndpoints[$cat]) {
-            if ($httpBypassedEndpoints -notcontains $bep) {
-                [void]$httpBypassedEndpoints.Add($bep)
+    $catMap = @{
+        'AAD'     = @('login.windows.net', 'login.microsoftonline.com', 'pas.windows.net')
+        'ARM'     = @('management.azure.com')
+        'Arc'     = @('gbl.his.arc.azure.com', 'agentserviceapi.guestconfiguration.azure.com')
+        'ArcData' = @("dataprocessingservice.$Region.arcdataservices.com",
+                      "telemetry.$Region.arcdataservices.com")
+        'AMA'     = @('global.handler.control.monitor.azure.com',
+                      "$Region.handler.control.monitor.azure.com")
+    }
+    foreach ($cat in $bypassCats) {
+        if ($catMap.ContainsKey($cat)) {
+            foreach ($ep in $catMap[$cat]) {
+                if ($httpBypassedEps -notcontains $ep) { [void]$httpBypassedEps.Add($ep) }
             }
         }
     }
 }
 
-foreach ($ep in $httpProbeEndpoints) {
+# =========================================================================
+# 7. ENDPOINT TESTS: DNS + TCP/443
+# =========================================================================
+
+Write-Banner "TESTING $($allTestable.Count) ENDPOINTS"
+
+$pi = 0
+foreach ($ep in $allTestable) {
     $ep = $ep.Trim()
     if (-not $ep) { continue }
+    $pi++
 
-    # If the endpoint is in the azcmagent bypass and we use a proxy, an HTTP test via proxy would give a false positive
-    if ($httpBypassedEndpoints -contains $ep) {
-        Add-Result -Endpoint $ep -HTTP 'SKIP (bypass)'
-        Write-Log "HTTP SKIP $ep (azcmagent proxy.bypass covers this endpoint — agent does not use a proxy)" Info -NoCount
+    $grp = if ($endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] } else { 'Core' }
+    Add-Result -Endpoint $ep -Group $grp
+
+    $pct = [math]::Round(($pi / $allTestable.Count) * 100)
+    $epShort = if ($ep.Length -gt 56) { $ep.Substring(0, 53) + '...' } else { $ep }
+    Write-Host ("`r  [{0,3}%] {1,-58}" -f $pct, $epShort) -NoNewline -ForegroundColor Gray
+
+    # --- DNS ---
+    $dns = $null
+    $dnsErr = $null
+    foreach ($a in 1..2) {
+        try {
+            $dns = Resolve-DnsName -Name $ep -ErrorAction Stop
+            $dnsErr = $null
+            break
+        }
+        catch {
+            $dnsErr = $_
+            if ($a -lt 2) { Start-Sleep -Milliseconds 300 }
+        }
+    }
+
+    if ($dnsErr) {
+        $lv = if ($grp -eq 'GNS') { 'Warn' } else { 'Fail' }
+        Log "DNS $lv $ep - $($dnsErr.Exception.Message)" $lv
+        $rr = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+        if ($rr) { $rr.DNS = $lv.ToUpper() }
+        if ($lv -eq 'Fail') {
+            Add-Issue -Sev 'HIGH' -Cat 'DNS' -Msg "Cannot resolve $ep" -Fix 'Check DNS/firewall'
+        }
         continue
     }
 
-    [void]$script:LogBuffer.Add('-' * 60)
-    Add-Result -Endpoint $ep
+    $rec = $dns | Where-Object { $_.Type -eq 'A' -and $_.IPAddress } | Select-Object -First 1
+    if (-not $rec) { $rec = $dns | Where-Object IPAddress | Select-Object -First 1 }
+    $ip   = $rec.IPAddress
+    $kind = if (Test-IsPrivateIp $ip) { 'PRIV' } else { 'PUB' }
 
+    $rr = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+    if ($rr) { $rr.IP = $ip; $rr.Type = $kind }
+
+    $cbp = $canBePrivate -contains $ep
+    $mm  = ($Mode -eq 'Private' -and $kind -eq 'PUB' -and $cbp) -or
+           ($Mode -eq 'Public'  -and $kind -eq 'PRIV')
+    if ($mm) {
+        Log "DNS WARN $ep -> $ip [$kind] mode mismatch" Warn
+        $rr2 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+        if ($rr2) { $rr2.DNS = 'WARN' }
+    }
+    else {
+        Log "DNS OK $ep -> $ip" OK
+        $rr2 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+        if ($rr2) { $rr2.DNS = 'OK' }
+    }
+
+    # --- TCP/443 ---
+    # Note: TCP tests L3/L4 reachability directly (not via proxy).
+    # In explicit proxy setups, this validates the network path through the firewall.
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $ok = Test-TcpPort -H $ep -P 443 -T 5000
+    $sw.Stop()
+    $ms = [math]::Round($sw.Elapsed.TotalMilliseconds, 0)
+
+    $rr3 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
+    if ($ok) {
+        Log "TCP OK ${ep}:443 (${ms}ms)" OK
+        if ($rr3) { $rr3.TCP = 'OK'; $rr3.Latency = "${ms}ms" }
+    }
+    else {
+        Log "TCP FAIL ${ep}:443" Fail
+        if ($rr3) { $rr3.TCP = 'FAIL'; $rr3.Latency = 'timeout' }
+        Add-Issue -Sev 'HIGH' -Cat 'TCP' -Msg "Cannot connect to ${ep}:443" -Fix 'Check firewall/proxy rules'
+    }
+}
+Write-Host ''   # Clear progress line
+
+# =========================================================================
+# 8. HTTP TESTS + PKI PROBE
+# =========================================================================
+
+foreach ($ep in $httpProbeEps) {
+    $ep = $ep.Trim()
+    if (-not $ep) { continue }
+    if ($httpBypassedEps -contains $ep) {
+        Add-Result -Endpoint $ep -HTTP 'SKIP'
+        Log "HTTP SKIP $ep (bypass)" Info -NoCount
+        continue
+    }
     try {
-        $resp = Invoke-WebRequestSafe -Uri "https://$ep" -TimeoutSec 10
-        $sw.Stop()
-        $elapsed = [math]::Round($sw.Elapsed.TotalSeconds, 2)
-        Write-Log "HTTP OK  $ep -> $($resp.StatusCode) in ${elapsed}s" OK
-        $existing4 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
-        if ($existing4) { $existing4.HTTP = "OK ($($resp.StatusCode))" }
+        $resp = Invoke-HttpSafe -Uri "https://$ep" -Timeout 10
+        Log "HTTP OK $ep -> $($resp.StatusCode)" OK
+        Add-Result -Endpoint $ep -HTTP "OK($($resp.StatusCode))"
     }
     catch {
-        if ($sw.IsRunning) { $sw.Stop() }
         $code = $null
         if ($_.Exception.Response) {
             try { $code = [int]$_.Exception.Response.StatusCode } catch { }
         }
         if ($code -in 400, 401, 403, 404) {
-            Write-Log "HTTP OK  $ep -> $code (expected without auth/without root handler)" OK
-            $existing4 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
-            if ($existing4) { $existing4.HTTP = "OK ($code)" }
-        }
-        elseif ($code) {
-            Write-Log "HTTP FAIL $ep -> $code" Fail
-            $existing4 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
-            if ($existing4) { $existing4.HTTP = "FAIL ($code)" }
+            Log "HTTP OK $ep -> $code" OK
+            Add-Result -Endpoint $ep -HTTP "OK($code)"
         }
         else {
-            Write-Log "HTTP FAIL $ep - $($_.Exception.Message)" Fail
-            $existing4 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
-            if ($existing4) { $existing4.HTTP = 'FAIL' }
+            Log "HTTP FAIL $ep" Fail
+            Add-Result -Endpoint $ep -HTTP 'FAIL'
+            Add-Issue -Sev 'MEDIUM' -Cat 'HTTP' -Msg "HTTP failed: $ep" -Fix 'Check proxy/firewall app rules'
         }
     }
 }
 
-# ---------------------------------------------------------------------------
-# azcmagent check
-# ---------------------------------------------------------------------------
-[void]$script:LogBuffer.Add('=' * 60)
-$azcm = Get-AzcmagentPath
-if ($azcm) {
-    $checkArgs = @('check', '--location', $Region, '--cloud', 'AzureCloud')
-    if ($CheckIncludeAll) {
-        # Official doc: '--extensions' and '--include-all' are ORTHOGONAL.
-        #   --extensions all -> endpoints for ALL extensions (SQL, etc.)
-        #   --include-all    -> EXTENDED use cases (e.g. Windows Server PAYG)
-        # We combine both for full coverage.
-        $checkArgs += @('--extensions', 'all', '--include-all')
-    }
-    elseif ($IncludeSQL) {
-        $checkArgs += @('--extensions', 'sql')
-    }
-    if ($Mode -eq 'Private') { $checkArgs += '--enable-pls-check' }
+# PKI HTTP probe — tests the REAL path SCHANNEL will use:
+#   If oneocsp.microsoft.com is in bypass → test DIRECT (no proxy)
+#   If NOT in bypass → test via WinHTTP proxy (likely fails on explicit proxy)
+if (-not $SkipPKI -and $script:WinHttpProxy) {
+    $uncPkiNow = Test-PkiBypassCoverage
+    $ocspBypassed = $uncPkiNow -notcontains 'oneocsp.microsoft.com'
 
-    Write-Log "Running: azcmagent $($checkArgs -join ' ')" Info -NoCount
-    Save-LogBuffer   # ensure ordering: header before the binary output
-    try {
-        $out = & $azcm @checkArgs 2>&1
-        Add-Content -Path $LogFilePath -Value $out
-        if ($LASTEXITCODE -eq 0) {
-            Write-Log 'azcmagent check completed (exit 0).' OK
+    if ($ocspBypassed) {
+        # Endpoint is in bypass — SCHANNEL will connect DIRECT, not via proxy
+        try {
+            $probeParams = @{
+                Uri = 'http://oneocsp.microsoft.com'
+                Method = 'Get'; UseBasicParsing = $true
+                TimeoutSec = 5; ErrorAction = 'Stop'
+            }
+            if ($PSVersionTable.PSVersion.Major -ge 6) {
+                $probeParams['NoProxy'] = $true
+            }
+            else {
+                $savedWP = [System.Net.WebRequest]::DefaultWebProxy
+                [System.Net.WebRequest]::DefaultWebProxy = $null
+            }
+            $resp = Invoke-WebRequest @probeParams
+            if ($PSVersionTable.PSVersion.Major -lt 6) {
+                [System.Net.WebRequest]::DefaultWebProxy = $savedWP
+            }
+            Log "PKI probe OK direct (bypass active)" OK
+            Add-Result -Endpoint 'oneocsp.microsoft.com' -HTTP "OK($($resp.StatusCode))"
+        }
+        catch {
+            try { if ($PSVersionTable.PSVersion.Major -lt 6) { [System.Net.WebRequest]::DefaultWebProxy = $savedWP } } catch { }
+            # OCSP responders return 4xx on bare GET — any HTTP response = reachable
+            $code = $null
+            try {
+                if ($_.Exception -and $_.Exception.Response) {
+                    $code = [int]$_.Exception.Response.StatusCode
+                }
+            } catch { }
+            if ($code -and $code -ge 200 -and $code -lt 600) {
+                Log "PKI probe OK direct -> $code (bypass active)" OK
+                Add-Result -Endpoint 'oneocsp.microsoft.com' -HTTP "OK($code)"
+            }
+            else {
+                $msg = $_.Exception.Message
+                Log "PKI probe FAIL direct: $msg" Fail
+                Add-Result -Endpoint 'oneocsp.microsoft.com' -HTTP 'FAIL'
+                Add-Issue -Sev 'HIGH' -Cat 'PKI Direct' `
+                    -Msg 'OCSP unreachable via direct path (bypass active but no route)' `
+                    -Fix 'Ensure firewall network/application rules allow direct HTTP:80 to PKI endpoints'
+            }
+        }
+    }
+    else {
+        # Endpoint NOT in bypass — SCHANNEL sends via proxy (will likely fail on explicit proxy)
+        try {
+            $resp = Invoke-HttpSafe -Uri 'http://oneocsp.microsoft.com' -Timeout 5 -UseProxy $script:WinHttpProxy
+            Log "PKI probe OK via WinHTTP proxy" OK
+            Add-Result -Endpoint 'oneocsp.microsoft.com' -HTTP "OK($($resp.StatusCode))"
+        }
+        catch {
+            $msg = $_.Exception.Message
+            if ($msg -match '407') {
+                Log "PKI probe: 407 proxy auth" Warn
+                Add-Result -Endpoint 'oneocsp.microsoft.com' -HTTP 'WARN'
+            }
+            else {
+                Log "PKI probe FAIL via proxy: $msg" Fail
+                Add-Result -Endpoint 'oneocsp.microsoft.com' -HTTP 'FAIL'
+                Add-Issue -Sev 'CRITICAL' -Cat 'PKI Proxy' `
+                    -Msg 'OCSP unreachable via WinHTTP proxy (non-proxy request on proxy port)' `
+                    -Fix 'Add PKI endpoints to proxy bypass (GPO NO_PROXY)'
+            }
+        }
+    }
+}
+
+# azcmagent check result (already ran during discovery)
+if ($null -ne $script:AzcmagentCheckExit) {
+    if ($script:AzcmagentCheckExit -eq 0) { Log 'azcmagent check: exit 0' OK }
+    else { Log "azcmagent check: exit $($script:AzcmagentCheckExit)" Fail }
+}
+elseif (-not $azcm) {
+    Log 'azcmagent not found - skipping check' Warn
+}
+
+Save-Log
+
+# =========================================================================
+# 9. RESULTS TABLE
+# =========================================================================
+
+Write-Banner 'RESULTS'
+
+$tbl = $script:Results | ForEach-Object { [pscustomobject]$_ }
+
+# Sort by group priority
+$grps = $tbl | Group-Object Group | Sort-Object @{ Expression = {
+    switch ($_.Name) {
+        'Core' { 0 }; 'PKI' { 1 }; 'SQL' { 2 }; 'AMA' { 3 }; 'MDE' { 4 }
+        'WAC'  { 5 }; 'KV'  { 6 }; 'HRW' { 7 }; 'UM'  { 8 }; 'GA'  { 9 }
+        'GNS'  { 10 }; default { 11 }
+    }
+} }
+
+# Pipe-delimited table (azcmagent check style)
+$hf = "  {0,-5} | {1,-50} | {2,-16} | {3,-4} | {4,-9} | {5,-7}"
+Write-Host ($hf -f 'Group', 'Endpoint', 'IP', 'Type', 'Result', 'Latency') -ForegroundColor Cyan
+Write-Host ("  {0,-5}-+-{1,-50}-+-{2,-16}-+-{3,-4}-+-{4,-9}-+-{5,-7}" -f `
+    ('-' * 5), ('-' * 50), ('-' * 16), ('-' * 4), ('-' * 9), ('-' * 7)) -ForegroundColor DarkGray
+
+foreach ($g in $grps) {
+    foreach ($r in $g.Group) {
+        $dnsOk  = $r.DNS  -notin @('FAIL', 'WARN', '-')
+        $tcpOk  = $r.TCP  -notin @('FAIL', '-')
+        $httpOk = ($r.HTTP -eq '-') -or ($r.HTTP -like 'OK*') -or ($r.HTTP -eq 'SKIP')
+        $fail   = ($r.DNS -eq 'FAIL') -or ($r.TCP -eq 'FAIL') -or ($r.HTTP -like 'FAIL*')
+        $warn   = ($r.DNS -eq 'WARN') -or ($r.HTTP -like 'WARN*')
+
+        # Compose result column (mimics azcmagent: Reachable / Unreachable / Warning)
+        if ($fail) {
+            $detail = @()
+            if ($r.DNS -eq 'FAIL') { $detail += 'DNS' }
+            if ($r.TCP -eq 'FAIL') { $detail += 'TCP' }
+            if ($r.HTTP -like 'FAIL*') { $detail += 'HTTP' }
+            $result = "FAIL($($detail -join ','))"
+        }
+        elseif ($warn) {
+            $result = 'Warning'
+        }
+        elseif ($r.HTTP -eq 'SKIP') {
+            $result = 'Reachable*'
         }
         else {
-            Write-Log "azcmagent check finished with exit $LASTEXITCODE." Fail
+            $result = 'Reachable'
+        }
+
+        $c = if ($fail) { 'Red' } elseif ($warn) { 'Yellow' } else { 'Green' }
+        Write-Host ($hf -f $r.Group, $r.Endpoint, $r.IP, $r.Type, $result, $r.Latency) -ForegroundColor $c
+    }
+}
+
+# Wildcard endpoints (informational)
+if ($wildcardEps.Count -gt 0) {
+    Write-Host ''
+    $wFmt = "  {0,-5} | {1,-50} | {2}"
+    Write-Host ($wFmt -f 'Group', 'Wildcard Endpoint', 'Note') -ForegroundColor DarkGray
+    Write-Host ("  {0,-5}-+-{1,-50}-+-{2}" -f ('-' * 5), ('-' * 50), ('-' * 30)) -ForegroundColor DarkGray
+    foreach ($w in $wildcardEps) {
+        $wg = if ($endpointGroupMap.ContainsKey($w)) { $endpointGroupMap[$w] } else { '-' }
+        Write-Host ($wFmt -f $wg, $w, 'Requires firewall rule (not testable)') -ForegroundColor DarkGray
+    }
+}
+
+# =========================================================================
+# 10. ISSUES
+# =========================================================================
+
+if ($script:Issues.Count -gt 0) {
+    Write-Banner "ISSUES ($($script:Issues.Count))"
+    $iFmt = "  {0,-3} | {1,-8} | {2,-12} | {3}"
+    Write-Host ($iFmt -f '#', 'Severity', 'Category', 'Message') -ForegroundColor Cyan
+    Write-Host ("  {0,-3}-+-{1,-8}-+-{2,-12}-+-{3}" -f ('-' * 3), ('-' * 8), ('-' * 12), ('-' * 50)) -ForegroundColor DarkGray
+    $ix = 0
+    foreach ($iss in $script:Issues) {
+        $ix++
+        $sc = switch ($iss.Severity) {
+            'CRITICAL' { 'Red' }; 'HIGH' { 'Red' }
+            'MEDIUM' { 'Yellow' }; 'WARN' { 'Yellow' }
+            default { 'Gray' }
+        }
+        Write-Host ($iFmt -f $ix, $iss.Severity, $iss.Category, $iss.Message) -ForegroundColor $sc
+        if ($iss.Fix) {
+            Write-Host ("  {0,-3} | {1,-8} | {2,-12} | Fix: {3}" -f '', '', '', $iss.Fix) -ForegroundColor DarkCyan
         }
     }
-    catch {
-        Write-Log "azcmagent check failed: $($_.Exception.Message)" Fail
-    }
-}
-else {
-    Write-Log 'azcmagent.exe not found - skipping check.' Warn
 }
 
-# ---------------------------------------------------------------------------
-# Summary
-# ---------------------------------------------------------------------------
-[void]$script:LogBuffer.Add('=' * 60)
-Write-Log ("Summary: OK={0}  Fail={1}  Warn={2}  Mode={3}  Region={4}" -f `
-        $script:Stats.OK, $script:Stats.Fail, $script:Stats.Warn, $Mode, $Region) Info -NoCount
-Write-Log "Script finished at $(Get-Date -Format o)" Info -NoCount
-Save-LogBuffer
-
-# ---------------------------------------------------------------------------
-# Results table (console + log)
-# ---------------------------------------------------------------------------
-$tableObjects = $script:Results | ForEach-Object { [pscustomobject]$_ }
+# =========================================================================
+# 11. FINAL SUMMARY
+# =========================================================================
 
 Write-Host ''
-Write-Host '=================== SUMMARY ===================' -ForegroundColor Cyan
+Write-Host ('=' * 74) -ForegroundColor DarkCyan
 
-$rowFormat = "{0,-5} {1,-55} {2,-26} {3,-8} {4,-5} {5,-5} {6,-12} {7,-9}"
-Write-Host ($rowFormat -f 'Group', 'Endpoint', 'IP', 'Type', 'DNS', 'TCP', 'HTTP', 'Latency') -ForegroundColor Cyan
-Write-Host ($rowFormat -f ('-' * 5), ('-' * 55), ('-' * 26), ('-' * 8), ('-' * 5), ('-' * 5), ('-' * 12), ('-' * 9)) -ForegroundColor DarkGray
+$fc = $script:Stats.Fail
+$wc = $script:Stats.Warn
+$oc = $script:Stats.OK
+$ic = $script:Issues.Count
 
-foreach ($r in $tableObjects) {
-    $hasFail = ($r.DNS -eq 'FAIL') -or ($r.TCP -eq 'FAIL') -or ($r.HTTP -like 'FAIL*')
-    $hasWarn = ($r.DNS -eq 'WARN')
-    $color   = if ($hasFail) { 'Red' } elseif ($hasWarn) { 'Yellow' } else { 'Green' }
-    Write-Host ($rowFormat -f $r.Group, $r.Endpoint, $r.IP, $r.Type, $r.DNS, $r.TCP, $r.HTTP, $r.Latency) -ForegroundColor $color
+# Only CRITICAL/HIGH issues cause FAIL; WARN/MEDIUM issues cause WARN status but exit 0
+$critIssues = @($script:Issues | Where-Object { $_.Severity -in @('CRITICAL', 'HIGH') })
+$hasFail    = ($fc -gt 0) -or ($critIssues.Count -gt 0)
+$hasWarn    = ($wc -gt 0) -or ($ic -gt $critIssues.Count)
+$summColor  = if ($hasFail) { 'Red' } elseif ($hasWarn) { 'Yellow' } else { 'Green' }
+$statusText = if ($hasFail) { 'FAIL' } elseif ($hasWarn) { 'WARN' } else { 'PASS' }
+
+$gwTag = if ($script:GatewayUrl) { ' [GW]' } else { '' }
+$preTag = if ($script:PreOnboarding) { ' [PRE-ONBOARDING]' } else { '' }
+Write-Host ("  STATUS: {0}  |  OK:{1} Fail:{2} Warn:{3} Issues:{4}  |  {5} {6}{7}{8}" -f `
+    $statusText, $oc, $fc, $wc, $ic, $Mode, $Region, $gwTag, $preTag) -ForegroundColor $summColor
+
+if ($script:InstalledExts.Count -gt 0) {
+    Write-Host "  Extensions: $($script:InstalledExts -join ', ')" -ForegroundColor DarkGray
 }
-
-Write-Host ''
-Write-Host ("Totals: OK={0}  Fail={1}  Warn={2}  Mode={3}  Region={4}" -f `
-        $script:Stats.OK, $script:Stats.Fail, $script:Stats.Warn, $Mode, $Region) -ForegroundColor Cyan
-
 if ($script:EffectiveProxy) {
-    Write-Host "Proxy used: $($script:EffectiveProxy)" -ForegroundColor DarkGray
+    Write-Host "  Proxy: $($script:EffectiveProxy)" -ForegroundColor DarkGray
 }
-else {
-    Write-Host 'Proxy used: Direct (no proxy)' -ForegroundColor DarkGray
-}
+Write-Host "  Log: $LogFilePath" -ForegroundColor DarkGray
+Write-Host ('=' * 74) -ForegroundColor DarkCyan
 
-# Append table to the log file
-$tableString = $tableObjects | Format-Table -AutoSize | Out-String
+# --- Append to log file ---
+$ts = $tbl | Format-Table -AutoSize | Out-String
 Add-Content -Path $LogFilePath -Value ''
-Add-Content -Path $LogFilePath -Value '=================== SUMMARY ==================='
-Add-Content -Path $LogFilePath -Value $tableString.TrimEnd()
-Add-Content -Path $LogFilePath -Value ("Totals: OK={0}  Fail={1}  Warn={2}  Mode={3}  Region={4}" -f `
-        $script:Stats.OK, $script:Stats.Fail, $script:Stats.Warn, $Mode, $Region)
-if ($script:EffectiveProxy) {
-    Add-Content -Path $LogFilePath -Value "Proxy used: $($script:EffectiveProxy)"
-}
-else {
-    Add-Content -Path $LogFilePath -Value 'Proxy used: Direct (no proxy)'
+Add-Content -Path $LogFilePath -Value '=================== RESULTS ==================='
+Add-Content -Path $LogFilePath -Value $ts.TrimEnd()
+Add-Content -Path $LogFilePath -Value ("Status: $statusText | OK=$oc Fail=$fc Warn=$wc Issues=$ic | $Mode $Region$gwTag")
+
+if ($ic -gt 0) {
+    Add-Content -Path $LogFilePath -Value ''
+    Add-Content -Path $LogFilePath -Value '=================== ISSUES ==================='
+    foreach ($iss in $script:Issues) {
+        Add-Content -Path $LogFilePath -Value "[$($iss.Severity)] $($iss.Category): $($iss.Message)"
+        if ($iss.Fix) { Add-Content -Path $LogFilePath -Value "  Fix: $($iss.Fix)" }
+    }
 }
 
-Write-Host "`nFull log: $LogFilePath" -ForegroundColor Cyan
-exit ([int]($script:Stats.Fail -gt 0))
+exit ([int]$hasFail)

--- a/script_automation/arc_endpoint_check/ArcEndpointCheck.ps1
+++ b/script_automation/arc_endpoint_check/ArcEndpointCheck.ps1
@@ -124,7 +124,7 @@ param(
 # Setup
 # ---------------------------------------------------------------------------
 $ErrorActionPreference = 'Stop'
-$ProgressPreference    = 'SilentlyContinue'   # acelera Invoke-WebRequest e Test-NetConnection
+$ProgressPreference    = 'SilentlyContinue'   # speeds up Invoke-WebRequest and Test-NetConnection
 
 $logDir = Split-Path -Path $LogFilePath -Parent
 if ($logDir -and -not (Test-Path $logDir)) {
@@ -252,53 +252,53 @@ function Invoke-WebRequestSafe {
         $params['ProxyUseDefaultCredentials'] = $true
     }
     elseif ($PSVersionTable.PSVersion.Major -ge 6) {
-        # PS 6+: espelha o agente, que IGNORA o proxy system-wide. Em PS 5.1 o
-        # mesmo efeito e obtido neutralizando o DefaultWebProxy do .NET no setup.
+        # PS 6+: mirror the agent, which IGNORES the system-wide proxy. On PS 5.1 the
+        # same effect is achieved by neutralizing .NET's DefaultWebProxy during setup.
         $params['NoProxy'] = $true
     }
     return Invoke-WebRequest @params
 }
 
 # ---------------------------------------------------------------------------
-# Detecao e exibicao de proxy
+# Proxy detection and display
 # ---------------------------------------------------------------------------
 $script:EffectiveProxy = $null
 
 function Get-ProxyDiagnostics {
-    Write-Log '=== DIAGNOSTICO DE PROXY ===' Info -NoCount
+    Write-Log '=== PROXY DIAGNOSTICS ===' Info -NoCount
     [void]$script:LogBuffer.Add('')
 
-    # Precedencia do proxy efetivo (usado nos testes HTTP deste script) — espelha
-    # o comportamento do Azure Connected Machine agent no Windows:
-    #   1) -ProxyUrl            (override explicito do operador)
-    #   2) azcmagent proxy.url  (config do agente — TEM PRECEDENCIA sobre env vars)
+    # Effective proxy precedence (used by this script's HTTP tests) — mirrors the
+    # behavior of the Azure Connected Machine agent on Windows:
+    #   1) -ProxyUrl            (explicit operator override)
+    #   2) azcmagent proxy.url  (agent config — TAKES PRECEDENCE over env vars)
     #   3) HTTPS_PROXY (env)    (system-wide)
-    # O agente IGNORA o proxy system-wide do Windows (WinHTTP/WinINET); por isso o
-    # WinHTTP abaixo e apenas REPORTADO, nunca aplicado automaticamente.
+    # The agent IGNORES the Windows system-wide proxy (WinHTTP/WinINET); that is why
+    # the WinHTTP value below is only REPORTED, never applied automatically.
     # Ref: https://learn.microsoft.com/azure/azure-arc/servers/manage-agent-proxy-settings
 
-    # 1) Parametro -ProxyUrl (validado como URI absoluta http/https)
+    # 1) -ProxyUrl parameter (validated as an absolute http/https URI)
     if ($ProxyUrl) {
         if (Test-IsValidProxyUri -Candidate $ProxyUrl) {
-            Write-Log "Proxy via parametro: $ProxyUrl" Info -NoCount
+            Write-Log "Proxy from parameter: $ProxyUrl" Info -NoCount
             $script:EffectiveProxy = $ProxyUrl
         }
         else {
-            Write-Log "Proxy via parametro INVALIDO (esperado http:// ou https://): $ProxyUrl" Warn
+            Write-Log "Proxy from parameter INVALID (expected http:// or https://): $ProxyUrl" Warn
         }
     }
 
-    # WinHTTP (apenas informativo — o agente ignora o proxy system-wide)
-    # Regex bilingue: EN "Proxy Server(s)" / pt-BR "Servidor(es) Proxy"
+    # WinHTTP (informational only — the agent ignores the system-wide proxy)
+    # Bilingual regex: EN "Proxy Server(s)" / pt-BR "Servidor(es) Proxy"
     try {
         $winhttp = netsh winhttp show proxy 2>$null
         $winhttpText = ($winhttp | Out-String).Trim()
         if ($winhttpText -match 'Proxy Server\(s\)\s*:\s*(.+)|Servidor\(es\) Proxy\s*:\s*(.+)') {
             $winhttpProxy = ($Matches[1], $Matches[2] | Where-Object { $_ } | Select-Object -First 1).Trim()
-            Write-Log "WinHTTP Proxy: $winhttpProxy (informativo — o agente ignora o proxy system-wide)" Info -NoCount
+            Write-Log "WinHTTP Proxy: $winhttpProxy (informational — the agent ignores the system-wide proxy)" Info -NoCount
         }
         else {
-            Write-Log 'WinHTTP Proxy: Direct (sem proxy)' Info -NoCount
+            Write-Log 'WinHTTP Proxy: Direct (no proxy)' Info -NoCount
         }
         if ($winhttpText -match 'Bypass List\s*:\s*(.+)|Lista de bypass\s*:\s*(.+)') {
             $bypassVal = ($Matches[1], $Matches[2] | Where-Object { $_ } | Select-Object -First 1).Trim()
@@ -306,13 +306,13 @@ function Get-ProxyDiagnostics {
         }
     }
     catch {
-        Write-Log "WinHTTP: nao foi possivel consultar ($($_.Exception.Message))" Warn
+        Write-Log "WinHTTP: unable to query ($($_.Exception.Message))" Warn
     }
 
-    # 2) azcmagent config (proxy.url TEM PRECEDENCIA sobre HTTPS_PROXY)
-    #    IMPORTANTE: azcmagent retorna frases informativas quando o valor nao esta
-    #    configurado (ex.: "proxy.url has not been set"). Validamos com
-    #    Test-IsValidProxyUri para aceitar APENAS URIs http/https reais.
+    # 2) azcmagent config (proxy.url TAKES PRECEDENCE over HTTPS_PROXY)
+    #    IMPORTANT: azcmagent returns informational phrases when the value is not
+    #    configured (e.g. "proxy.url has not been set"). We validate with
+    #    Test-IsValidProxyUri to accept ONLY real http/https URIs.
     $azcm = Get-AzcmagentPath
     if ($azcm) {
         try {
@@ -326,12 +326,12 @@ function Get-ProxyDiagnostics {
                 }
             }
             else {
-                # Mensagem informativa (ex.: "proxy.url has not been set")
+                # Informational message (e.g. "proxy.url has not been set")
                 if ($rawProxyUrlTrimmed) {
                     Write-Log "azcmagent proxy.url: $rawProxyUrlTrimmed" Info -NoCount
                 }
                 else {
-                    Write-Log 'azcmagent proxy.url: (nao configurado)' Info -NoCount
+                    Write-Log 'azcmagent proxy.url: (not configured)' Info -NoCount
                 }
             }
 
@@ -342,11 +342,11 @@ function Get-ProxyDiagnostics {
             }
         }
         catch {
-            Write-Log "azcmagent config: falha ao consultar ($($_.Exception.Message))" Warn
+            Write-Log "azcmagent config: failed to query ($($_.Exception.Message))" Warn
         }
     }
 
-    # 3) Environment variables (verifica Machine -> Process -> User)
+    # 3) Environment variables (checks Machine -> Process -> User)
     $envProxy = [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'Machine')
     if (-not $envProxy) { $envProxy = [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'Process') }
     if (-not $envProxy) { $envProxy = [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'User') }
@@ -360,29 +360,29 @@ function Get-ProxyDiagnostics {
                 $script:EffectiveProxy = $envProxy
             }
             else {
-                Write-Log "Env HTTPS_PROXY INVALIDO (esperado http:// ou https://): $envProxy" Warn
+                Write-Log "Env HTTPS_PROXY INVALID (expected http:// or https://): $envProxy" Warn
             }
         }
     }
     else {
-        Write-Log 'Env HTTPS_PROXY: (nao definido)' Info -NoCount
+        Write-Log 'Env HTTPS_PROXY: (not set)' Info -NoCount
     }
     if ($envNoProxy) {
         Write-Log "Env NO_PROXY: $envNoProxy" Info -NoCount
     }
 
     if ($script:EffectiveProxy) {
-        Write-Log "Proxy efetivo para testes HTTP: $($script:EffectiveProxy)" Info -NoCount
+        Write-Log "Effective proxy for HTTP tests: $($script:EffectiveProxy)" Info -NoCount
     }
     else {
-        Write-Log 'Proxy efetivo: Direct (sem proxy — testes HTTP vao direto, como o agente)' Info -NoCount
+        Write-Log 'Effective proxy: Direct (no proxy — HTTP tests go direct, like the agent)' Info -NoCount
     }
 
     [void]$script:LogBuffer.Add('')
 }
 
 # ---------------------------------------------------------------------------
-# Deteccao automatica Public vs Private
+# Automatic Public vs Private detection
 # ---------------------------------------------------------------------------
 function Get-AzcmagentPath {
     $candidate = Join-Path $env:ProgramFiles 'AzureConnectedMachineAgent\azcmagent.exe'
@@ -398,7 +398,7 @@ function Test-IsPrivateIp {
     }
     catch { return $false }
 
-    # RFC1918 + 100.64/10 (CGNAT, comum em redes corporativas)
+    # RFC1918 + 100.64/10 (CGNAT, common in corporate networks)
     return ($bytes[0] -eq 10) -or
            ($bytes[0] -eq 192 -and $bytes[1] -eq 168) -or
            ($bytes[0] -eq 172 -and $bytes[1] -ge 16 -and $bytes[1] -le 31) -or
@@ -406,7 +406,7 @@ function Test-IsPrivateIp {
 }
 
 function Resolve-ArcMode {
-    Write-Log 'Detectando modo Arc (Public/Private)...' Info -NoCount
+    Write-Log 'Detecting Arc mode (Public/Private)...' Info -NoCount
 
     # 1) Via azcmagent show -j
     $azcm = Get-AzcmagentPath
@@ -415,52 +415,52 @@ function Resolve-ArcMode {
             $json = & $azcm show -j 2>$null | ConvertFrom-Json
             $pls = $json.privateLinkScope
             if ($pls) {
-                Write-Log "azcmagent reporta privateLinkScope: $pls" Info -NoCount
+                Write-Log "azcmagent reports privateLinkScope: $pls" Info -NoCount
                 return 'Private'
             }
             else {
-                # NAO conclui Public aqui: cai para o heuristico DNS abaixo. O
-                # Private Link pode ser "via DNS" (Private DNS Zones) sem o agente
-                # expor o PLS localmente em 'azcmagent show -j'.
-                Write-Log 'azcmagent nao reporta privateLinkScope; confirmando via DNS...' Info -NoCount
+                # Do NOT conclude Public here: fall through to the DNS heuristic below.
+                # Private Link can be "DNS-based" (Private DNS Zones) without the agent
+                # exposing the PLS locally in 'azcmagent show -j'.
+                Write-Log 'azcmagent does not report privateLinkScope; confirming via DNS...' Info -NoCount
             }
         }
         catch {
-            Write-Log "Falha ao consultar azcmagent show -j: $($_.Exception.Message). Caindo para fallback DNS." Warn
+            Write-Log "Failed to query azcmagent show -j: $($_.Exception.Message). Falling back to DNS." Warn
         }
     }
     else {
-        Write-Log 'azcmagent.exe nao encontrado. Usando fallback DNS.' Warn
+        Write-Log 'azcmagent.exe not found. Using DNS fallback.' Warn
     }
 
-    # 2) Fallback: resolver gbl.his.arc.azure.com
+    # 2) Fallback: resolve gbl.his.arc.azure.com
     try {
         $dns = Resolve-DnsName -Name 'gbl.his.arc.azure.com' -Type A -ErrorAction Stop
         $ip  = ($dns | Where-Object IPAddress | Select-Object -First 1).IPAddress
         if (Test-IsPrivateIp -Ip $ip) {
-            Write-Log "gbl.his.arc.azure.com resolve para IP privado ($ip) -> Private Link" Info -NoCount
+            Write-Log "gbl.his.arc.azure.com resolves to a private IP ($ip) -> Private Link" Info -NoCount
             return 'Private'
         }
         else {
-            Write-Log "gbl.his.arc.azure.com resolve para IP publico ($ip) -> Public" Info -NoCount
+            Write-Log "gbl.his.arc.azure.com resolves to a public IP ($ip) -> Public" Info -NoCount
             return 'Public'
         }
     }
     catch {
-        Write-Log 'Nao foi possivel resolver gbl.his.arc.azure.com - assumindo Public.' Warn
+        Write-Log 'Could not resolve gbl.his.arc.azure.com - assuming Public.' Warn
         return 'Public'
     }
 }
 
 # ---------------------------------------------------------------------------
-# Detecao de modo e proxy
+# Mode and proxy detection
 # ---------------------------------------------------------------------------
 Get-ProxyDiagnostics
 
-# Alinhamento com o agente: o Azure Connected Machine agent IGNORA o proxy
-# system-wide do Windows (WinINET/WinHTTP). Se nenhum proxy efetivo foi
-# detectado, neutralizamos o DefaultWebProxy do .NET (PS 5.1) para que os
-# testes HTTP tambem vao direto. Em PS 6+ isso e feito via -NoProxy.
+# Alignment with the agent: the Azure Connected Machine agent IGNORES the Windows
+# system-wide proxy (WinINET/WinHTTP). If no effective proxy was detected, we
+# neutralize .NET's DefaultWebProxy (PS 5.1) so that the HTTP tests also go direct.
+# On PS 6+ this is done via -NoProxy.
 if (-not $script:EffectiveProxy -and $PSVersionTable.PSVersion.Major -lt 6) {
     try { [System.Net.WebRequest]::DefaultWebProxy = $null } catch { }
 }
@@ -468,19 +468,19 @@ if (-not $script:EffectiveProxy -and $PSVersionTable.PSVersion.Major -lt 6) {
 if ($Mode -eq 'Auto') {
     $Mode = Resolve-ArcMode
 }
-Write-Log "Modo selecionado: $Mode | Regiao: $Region" Info -NoCount
+Write-Log "Selected mode: $Mode | Region: $Region" Info -NoCount
 
-# Reset stats: fase de testes comeca aqui (detecao nao conta)
+# Reset stats: the test phase starts here (detection does not count)
 $script:Stats.OK   = 0
 $script:Stats.Fail = 0
 $script:Stats.Warn = 0
 
 # ---------------------------------------------------------------------------
-# Endpoints — organizados por grupo funcional
+# Endpoints — organized by functional group
 # ---------------------------------------------------------------------------
 
-# Endpoints que PODEM resolver para IP privado via Azure Private Link Scope.
-# Tudo que NAO esta nesta lista e sempre publico — nao gerar WARN em modo Private.
+# Endpoints that CAN resolve to a private IP via Azure Private Link Scope.
+# Everything NOT in this list is always public — do not raise a WARN in Private mode.
 $canBePrivateEndpoints = @(
     'gbl.his.arc.azure.com'
     'agentserviceapi.guestconfiguration.azure.com'
@@ -488,62 +488,62 @@ $canBePrivateEndpoints = @(
     'global.handler.control.monitor.azure.com'
 )
 
-# Core Arc (obrigatorios) — alinhado a network-requirements do Connected Machine agent.
+# Core Arc (required) — aligned with the Connected Machine agent network-requirements.
 # Doc: https://learn.microsoft.com/azure/azure-arc/servers/network-requirements
 $coreEndpoints = @(
-    # AAD / Identity (sempre; Public)
+    # AAD / Identity (always; Public)
     'login.windows.net'
     'login.microsoftonline.com'
     'pas.windows.net'
 
-    # ARM (conexao/desconexao; Public salvo Resource Management Private Link)
+    # ARM (connect/disconnect; Public unless Resource Management Private Link)
     'management.azure.com'
 
-    # Arc HIMDS (sempre; Private via PLS)
+    # Arc HIMDS (always; Private via PLS)
     'gbl.his.arc.azure.com'
 
-    # Guest Configuration / gestao de extensoes (sempre; Private via PLS)
+    # Guest Configuration / extension management (always; Private via PLS)
     'agentserviceapi.guestconfiguration.azure.com'
 
-    # Instalacao/atualizacao do agente (Public)
+    # Agent install/update (Public)
     'packages.microsoft.com'
     'download.microsoft.com'
 
-    # Telemetria (opcional; NAO usado em agentes 1.24+; Public)
+    # Telemetry (optional; NOT used on agents 1.24+; Public)
     'dc.services.visualstudio.com'
 )
 
-# SQL endpoints (opcional via -IncludeSQL) — Arc-enabled SQL Server.
-# Doc: network-requirements + sql/.../data-collection. Todos Public; TLS 1.2/1.3.
+# SQL endpoints (optional via -IncludeSQL) — Arc-enabled SQL Server.
+# Doc: network-requirements + sql/.../data-collection. All Public; TLS 1.2/1.3.
 $sqlEndpoints = @()
 if ($IncludeSQL) {
     $sqlEndpoints = @(
-        # Data processing service + telemetria (extensoes a partir de mar/2024)
+        # Data processing service + telemetry (extensions from Mar/2024 onward)
         "dataprocessingservice.$Region.arcdataservices.com"
         "telemetry.$Region.arcdataservices.com"
-        # Legado: usado por extensoes ate 13/fev/2024
+        # Legacy: used by extensions until Feb 13, 2024
         "san-af-$Region-prod.azurewebsites.net"
-        # Autenticacao Microsoft Entra do Arc SQL (Public). So necessario se usar
-        # Entra auth; NAO e endpoint core do agente. Reachable direto, mas pode ser
-        # bloqueado em proxy split-tunnel -> apenas DNS/TCP (sem HTTP probe).
+        # Arc SQL Microsoft Entra authentication (Public). Only needed when using
+        # Entra auth; NOT a core agent endpoint. Reachable directly, but may be
+        # blocked on a split-tunnel proxy -> DNS/TCP only (no HTTP probe).
         'graph.microsoft.com'
     )
 }
 
-# AMA endpoints (opcional via -IncludeAMA) — Azure Monitor Agent.
-# Doc: azure-monitor-agent-network-configuration. Endpoints <workspace-id>.ods e
-# <dce>.ingest.monitor exigem IDs especificos -> nao testaveis genericamente.
+# AMA endpoints (optional via -IncludeAMA) — Azure Monitor Agent.
+# Doc: azure-monitor-agent-network-configuration. The <workspace-id>.ods and
+# <dce>.ingest.monitor endpoints require specific IDs -> not generically testable.
 $amaEndpoints = @()
 if ($IncludeAMA) {
     $amaEndpoints = @(
         'global.handler.control.monitor.azure.com'   # control service
         'global.prod.microsoftmetrics.com'           # metrics service
-        "$Region.handler.control.monitor.azure.com"  # DCRs da regiao
-        "$Region.monitoring.azure.com"               # custom metrics (opcional)
+        "$Region.handler.control.monitor.azure.com"  # regional DCRs
+        "$Region.monitoring.azure.com"               # custom metrics (optional)
     )
 }
 
-# MDE endpoints (opcional via -IncludeMDE)
+# MDE endpoints (optional via -IncludeMDE)
 $mdeEndpoints = @()
 if ($IncludeMDE) {
     $mdeEndpoints = @(
@@ -552,9 +552,9 @@ if ($IncludeMDE) {
     )
 }
 
-# WAC endpoints (opcional via -IncludeWAC)
-# Nota: 'pas.windows.net' ja consta em $coreEndpoints e o $endpointGroupMap
-# preserva a precedencia Core, evitando duplicacao no sumario.
+# WAC endpoints (optional via -IncludeWAC)
+# Note: 'pas.windows.net' is already in $coreEndpoints and $endpointGroupMap
+# preserves Core precedence, avoiding duplication in the summary.
 $wacEndpoints = @()
 if ($IncludeWAC) {
     $wacEndpoints = @(
@@ -562,24 +562,24 @@ if ($IncludeWAC) {
     )
 }
 
-# Endpoints que respondem HTTP (validacao L7 — 200/400/401/403/404 = reachable).
-# NAO inclui graph.microsoft.com: e endpoint de Entra auth do Arc SQL (opcional) e
-# costuma ser bloqueado em proxy split-tunnel; o proprio teste oficial de
-# conectividade do Arc SQL valida apenas DPS + telemetria.
+# Endpoints that respond to HTTP (L7 validation — 200/400/401/403/404 = reachable).
+# Does NOT include graph.microsoft.com: it is the Arc SQL Entra auth endpoint (optional)
+# and is often blocked on a split-tunnel proxy; the official Arc SQL connectivity
+# test itself validates only DPS + telemetry.
 $httpProbeEndpoints = @(
     'login.windows.net'
     'login.microsoftonline.com'
     'management.azure.com'
 )
 if ($IncludeSQL) {
-    # Alinhado ao teste oficial do Arc SQL: DPS espera 200; telemetria espera 401
-    # (ambos tratados como reachable aqui).
+    # Aligned with the official Arc SQL test: DPS expects 200; telemetry expects 401
+    # (both treated as reachable here).
     $httpProbeEndpoints += "dataprocessingservice.$Region.arcdataservices.com"
     $httpProbeEndpoints += "telemetry.$Region.arcdataservices.com"
 }
 
-# Mapeia grupo por endpoint para o sumario. Core tem PRECEDENCIA: se um endpoint
-# aparece em mais de um grupo (ex.: pas.windows.net em Core e WAC), mantemos 'Core'.
+# Maps a group per endpoint for the summary. Core has PRECEDENCE: if an endpoint
+# appears in more than one group (e.g. pas.windows.net in Core and WAC), we keep 'Core'.
 $endpointGroupMap = @{}
 foreach ($ep in $coreEndpoints) { $endpointGroupMap[$ep] = 'Core' }
 foreach ($ep in $sqlEndpoints)  { if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = 'SQL' } }
@@ -587,20 +587,20 @@ foreach ($ep in $amaEndpoints)  { if (-not $endpointGroupMap.ContainsKey($ep)) {
 foreach ($ep in $mdeEndpoints)  { if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = 'MDE' } }
 foreach ($ep in $wacEndpoints)  { if (-not $endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] = 'WAC' } }
 
-# Dynamic allowlist (somente em modo publico; em PLS o trafego e via PE)
+# Dynamic allowlist (Public mode only; under PLS traffic goes via PE)
 $dynamicEndpoints = @()
 if ($Mode -eq 'Public') {
     try {
-        Write-Log 'Buscando endpoints dinamicos do guestnotificationservice...' Info -NoCount
+        Write-Log 'Fetching dynamic endpoints from guestnotificationservice...' Info -NoCount
         $uri  = "https://guestnotificationservice.azure.com/urls/allowlist?api-version=2020-01-01&location=$Region"
         $resp = Invoke-WebRequestSafe -Uri $uri
         $dynamicEndpoints = @($resp.Content | ConvertFrom-Json) | Where-Object { $_ }
         if ($dynamicEndpoints.Count -gt 0) {
             $totalGNS = $dynamicEndpoints.Count
 
-            # Filtrar: manter apenas endpoints primarios da regiao.
-            # Namespaces primarios contem '<N>p-' (ex: 1p-, 2p-), secundarios contem '<N>s-'.
-            # Extrair cluster IDs dos primarios e filtrar children por eles.
+            # Filter: keep only the region's primary endpoints.
+            # Primary namespaces contain '<N>p-' (e.g. 1p-, 2p-), secondary contain '<N>s-'.
+            # Extract cluster IDs from the primaries and filter children by them.
             $primaryClusterIds = [System.Collections.ArrayList]::new()
             foreach ($dep in $dynamicEndpoints) {
                 if ($dep -match '^azgn-.+\dp-.+?-(\w+)\.servicebus') {
@@ -612,7 +612,7 @@ if ($Mode -eq 'Public') {
                 $filteredGNS = [System.Collections.ArrayList]::new()
                 foreach ($dep in $dynamicEndpoints) {
                     if ($dep -match '^azgn-') {
-                        [void]$filteredGNS.Add($dep)   # sempre manter namespace-level
+                        [void]$filteredGNS.Add($dep)   # always keep namespace-level
                     }
                     else {
                         foreach ($cid in $primaryClusterIds) {
@@ -626,14 +626,14 @@ if ($Mode -eq 'Public') {
                 $skipped = $totalGNS - $filteredGNS.Count
                 $dynamicEndpoints = @($filteredGNS)
                 if ($skipped -gt 0) {
-                    Write-Log "Endpoints dinamicos obtidos: $totalGNS total, $($filteredGNS.Count) primarios ($skipped secundarios filtrados)" OK
+                    Write-Log "Dynamic endpoints obtained: $totalGNS total, $($filteredGNS.Count) primary ($skipped secondary filtered out)" OK
                 }
                 else {
-                    Write-Log "Endpoints dinamicos obtidos: $totalGNS endpoint(s)" OK
+                    Write-Log "Dynamic endpoints obtained: $totalGNS endpoint(s)" OK
                 }
             }
             else {
-                Write-Log "Endpoints dinamicos obtidos: $totalGNS endpoint(s)" OK
+                Write-Log "Dynamic endpoints obtained: $totalGNS endpoint(s)" OK
             }
 
             foreach ($dep in $dynamicEndpoints) {
@@ -642,14 +642,14 @@ if ($Mode -eq 'Public') {
         }
     }
     catch {
-        # Allowlist dinamica e AUXILIAR: sua indisponibilidade nao deve derrubar o
-        # exit code (WARN, nao FAIL). Comum ao forcar -Mode Public num host que, na
-        # pratica, roteia o GNS via Private Link / firewall.
-        Write-Log "Falha ao obter endpoints dinamicos (allowlist auxiliar): $($_.Exception.Message)" Warn
+        # The dynamic allowlist is AUXILIARY: its unavailability must not break the
+        # exit code (WARN, not FAIL). Common when forcing -Mode Public on a host that,
+        # in practice, routes GNS via Private Link / firewall.
+        Write-Log "Failed to obtain dynamic endpoints (auxiliary allowlist): $($_.Exception.Message)" Warn
     }
 }
 else {
-    Write-Log 'Modo Private: pulando consulta de allowlist publico.' Info -NoCount
+    Write-Log 'Private mode: skipping public allowlist query.' Info -NoCount
 }
 
 $allEndpoints = @(
@@ -659,23 +659,23 @@ $allEndpoints = @(
     Select-Object -Unique
 )
 
-Write-Log "Total de endpoints a testar: $($allEndpoints.Count)" Info -NoCount
+Write-Log "Total endpoints to test: $($allEndpoints.Count)" Info -NoCount
 [void]$script:LogBuffer.Add('')
 
 # ---------------------------------------------------------------------------
-# Testes: DNS + TCP/443 (validacao de coerencia com o modo detectado)
+# Tests: DNS + TCP/443 (consistency check against the detected mode)
 # ---------------------------------------------------------------------------
 foreach ($ep in $allEndpoints) {
     $ep = $ep.Trim()
     if (-not $ep) { continue }
 
-    Write-Verbose "Testando: $ep"
+    Write-Verbose "Testing: $ep"
 
     [void]$script:LogBuffer.Add('-' * 60)
     $group = if ($endpointGroupMap.ContainsKey($ep)) { $endpointGroupMap[$ep] } else { 'Dyn' }
     Add-Result -Endpoint $ep -Group $group
 
-    # DNS (com 1 retry em falha transitoria, ex.: SERVFAIL ao resolver muitos nomes)
+    # DNS (with 1 retry on a transient failure, e.g. SERVFAIL when resolving many names)
     $dns = $null
     $dnsErr = $null
     foreach ($attempt in 1..2) {
@@ -683,12 +683,12 @@ foreach ($ep in $allEndpoints) {
         catch { $dnsErr = $_; if ($attempt -lt 2) { Start-Sleep -Milliseconds 300 } }
     }
     if ($dnsErr) {
-        # Endpoints dinamicos (GNS) sao AUXILIARES: uma falha de DNS neles vira WARN
-        # (nao FAIL), pois um SERVFAIL transitorio ao resolver dezenas de nomes
-        # 'servicebus' nao deve derrubar o exit code. Demais grupos permanecem FAIL.
+        # Dynamic endpoints (GNS) are AUXILIARY: a DNS failure on them becomes WARN
+        # (not FAIL), because a transient SERVFAIL when resolving dozens of
+        # 'servicebus' names must not break the exit code. Other groups stay FAIL.
         $existingD = $script:Results | Where-Object { $_.Endpoint -eq $ep }
         if ($group -eq 'GNS') {
-            Write-Log "DNS WARN $ep - $($dnsErr.Exception.Message) (endpoint dinamico/auxiliar)" Warn
+            Write-Log "DNS WARN $ep - $($dnsErr.Exception.Message) (dynamic/auxiliary endpoint)" Warn
             if ($existingD) { $existingD.DNS = 'WARN' }
         }
         else {
@@ -698,10 +698,10 @@ foreach ($ep in $allEndpoints) {
         continue
     }
 
-    # Preferir IPv4 (registro A): o Azure Private Link e a maioria dos endpoints
-    # Arc sao resolvidos por A-record. Um AAAA (IPv6) publico pode coexistir com
-    # o A privado; se escolhido, causa classificacao PUBLIC incorreta e testes
-    # por um caminho IPv6 possivelmente inexistente/nao roteado.
+    # Prefer IPv4 (A record): Azure Private Link and most Arc endpoints are resolved
+    # by A record. A public AAAA (IPv6) may coexist with the private A; if chosen, it
+    # causes an incorrect PUBLIC classification and tests over a possibly
+    # nonexistent/unrouted IPv6 path.
     $rec = $dns | Where-Object { $_.Type -eq 'A' -and $_.IPAddress } | Select-Object -First 1
     if (-not $rec) { $rec = $dns | Where-Object IPAddress | Select-Object -First 1 }
     $ip   = $rec.IPAddress
@@ -711,9 +711,9 @@ foreach ($ep in $allEndpoints) {
     $existing = $script:Results | Where-Object { $_.Endpoint -eq $ep }
     if ($existing) { $existing.IP = $ip; $existing.Type = $kind }
 
-    # Alerta de mismatch DNS x modo
-    # Apenas endpoints em $canBePrivateEndpoints devem resolver para IP privado.
-    # Todos os outros (AAD, ARM, CDN, SQL, AMA, MDE, WAC, GNS) sao sempre publicos.
+    # DNS vs mode mismatch alert
+    # Only endpoints in $canBePrivateEndpoints should resolve to a private IP.
+    # All others (AAD, ARM, CDN, SQL, AMA, MDE, WAC, GNS) are always public.
     $canBePrivate = $canBePrivateEndpoints -contains $ep
     $mismatch = $false
     if ($Mode -eq 'Private' -and $kind -eq 'PUBLIC' -and $canBePrivate) {
@@ -723,7 +723,7 @@ foreach ($ep in $allEndpoints) {
         $mismatch = $true
     }
     if ($mismatch) {
-        Write-Log "DNS WARN $ep -> $ip [$kind] (esperado para modo $Mode era o oposto)" Warn
+        Write-Log "DNS WARN $ep -> $ip [$kind] (expected the opposite for $Mode mode)" Warn
         $existing2 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
         if ($existing2) { $existing2.DNS = 'WARN' }
     }
@@ -733,7 +733,7 @@ foreach ($ep in $allEndpoints) {
         if ($existing2) { $existing2.DNS = 'OK' }
     }
 
-    # TCP/443 (TcpClient com timeout — muito mais rapido que Test-NetConnection)
+    # TCP/443 (TcpClient with timeout — much faster than Test-NetConnection)
     $tcpSw = [System.Diagnostics.Stopwatch]::StartNew()
     $tcpOk = Test-TcpPort -ComputerName $ep -Port 443 -TimeoutMs 5000
     $tcpSw.Stop()
@@ -745,14 +745,14 @@ foreach ($ep in $allEndpoints) {
         if ($existing3) { $existing3.TCP = 'OK'; $existing3.Latency = "${latencyMs}ms" }
     }
     else {
-        Write-Log "TCP FAIL ${ep}:443 (timeout/recusado)" Fail
+        Write-Log "TCP FAIL ${ep}:443 (timeout/refused)" Fail
         if ($existing3) { $existing3.TCP = 'FAIL'; $existing3.Latency = 'timeout' }
     }
 }
 
 # ---------------------------------------------------------------------------
-# Testes HTTP (401/403/400 sao considerados sucesso: endpoint exige auth)
-# Detecta azcmagent proxy.bypass para pular HTTP tests em endpoints bypassados
+# HTTP tests (401/403/400 are treated as success: endpoint requires auth)
+# Detects azcmagent proxy.bypass to skip HTTP tests on bypassed endpoints
 # ---------------------------------------------------------------------------
 $proxyBypassCategories = @()
 $azcmPath = Get-AzcmagentPath
@@ -770,12 +770,12 @@ if ($azcmPath -and $script:EffectiveProxy) {
     catch { }
 }
 
-# Mapa de categorias de bypass -> endpoints afetados (conforme doc oficial:
+# Map of bypass categories -> affected endpoints (per the official doc:
 # https://learn.microsoft.com/azure/azure-arc/servers/manage-agent-proxy-settings).
-# IMPORTANTE: 'graph.microsoft.com' NAO e coberto por nenhum bypass — o agente
-# usa o proxy para ele; por isso ele NAO deve ser pulado nos testes HTTP.
-# 'ArcData' e valido a partir do agente 1.36; em versoes anteriores os endpoints
-# arcdataservices ficavam sob a categoria 'Arc'.
+# IMPORTANT: 'graph.microsoft.com' is NOT covered by any bypass — the agent
+# uses the proxy for it; therefore it must NOT be skipped in the HTTP tests.
+# 'ArcData' is valid from agent 1.36 onward; in earlier versions the
+# arcdataservices endpoints fell under the 'Arc' category.
 $bypassCategoryEndpoints = @{
     'AAD'     = @('login.windows.net', 'login.microsoftonline.com', 'pas.windows.net')
     'ARM'     = @('management.azure.com')
@@ -807,10 +807,10 @@ foreach ($ep in $httpProbeEndpoints) {
     $ep = $ep.Trim()
     if (-not $ep) { continue }
 
-    # Se o endpoint esta no bypass do azcmagent e usamos proxy, HTTP test via proxy daria falso positivo
+    # If the endpoint is in the azcmagent bypass and we use a proxy, an HTTP test via proxy would give a false positive
     if ($httpBypassedEndpoints -contains $ep) {
         Add-Result -Endpoint $ep -HTTP 'SKIP (bypass)'
-        Write-Log "HTTP SKIP $ep (azcmagent proxy.bypass cobre este endpoint — agente nao usa proxy)" Info -NoCount
+        Write-Log "HTTP SKIP $ep (azcmagent proxy.bypass covers this endpoint — agent does not use a proxy)" Info -NoCount
         continue
     }
 
@@ -822,7 +822,7 @@ foreach ($ep in $httpProbeEndpoints) {
         $resp = Invoke-WebRequestSafe -Uri "https://$ep" -TimeoutSec 10
         $sw.Stop()
         $elapsed = [math]::Round($sw.Elapsed.TotalSeconds, 2)
-        Write-Log "HTTP OK  $ep -> $($resp.StatusCode) em ${elapsed}s" OK
+        Write-Log "HTTP OK  $ep -> $($resp.StatusCode) in ${elapsed}s" OK
         $existing4 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
         if ($existing4) { $existing4.HTTP = "OK ($($resp.StatusCode))" }
     }
@@ -833,7 +833,7 @@ foreach ($ep in $httpProbeEndpoints) {
             try { $code = [int]$_.Exception.Response.StatusCode } catch { }
         }
         if ($code -in 400, 401, 403, 404) {
-            Write-Log "HTTP OK  $ep -> $code (esperado sem auth/sem root handler)" OK
+            Write-Log "HTTP OK  $ep -> $code (expected without auth/without root handler)" OK
             $existing4 = $script:Results | Where-Object { $_.Endpoint -eq $ep }
             if ($existing4) { $existing4.HTTP = "OK ($code)" }
         }
@@ -858,10 +858,10 @@ $azcm = Get-AzcmagentPath
 if ($azcm) {
     $checkArgs = @('check', '--location', $Region, '--cloud', 'AzureCloud')
     if ($CheckIncludeAll) {
-        # Doc oficial: '--extensions' e '--include-all' sao ORTOGONAIS.
-        #   --extensions all -> endpoints de TODAS as extensoes (SQL, etc.)
-        #   --include-all    -> casos de uso ESTENDIDOS (ex.: Windows Server PAYG)
-        # Combinamos os dois para cobertura total.
+        # Official doc: '--extensions' and '--include-all' are ORTHOGONAL.
+        #   --extensions all -> endpoints for ALL extensions (SQL, etc.)
+        #   --include-all    -> EXTENDED use cases (e.g. Windows Server PAYG)
+        # We combine both for full coverage.
         $checkArgs += @('--extensions', 'all', '--include-all')
     }
     elseif ($IncludeSQL) {
@@ -869,42 +869,42 @@ if ($azcm) {
     }
     if ($Mode -eq 'Private') { $checkArgs += '--enable-pls-check' }
 
-    Write-Log "Executando: azcmagent $($checkArgs -join ' ')" Info -NoCount
-    Save-LogBuffer   # garante ordem: cabecalho antes do output do binario
+    Write-Log "Running: azcmagent $($checkArgs -join ' ')" Info -NoCount
+    Save-LogBuffer   # ensure ordering: header before the binary output
     try {
         $out = & $azcm @checkArgs 2>&1
         Add-Content -Path $LogFilePath -Value $out
         if ($LASTEXITCODE -eq 0) {
-            Write-Log 'azcmagent check concluido (exit 0).' OK
+            Write-Log 'azcmagent check completed (exit 0).' OK
         }
         else {
-            Write-Log "azcmagent check terminou com exit $LASTEXITCODE." Fail
+            Write-Log "azcmagent check finished with exit $LASTEXITCODE." Fail
         }
     }
     catch {
-        Write-Log "azcmagent check falhou: $($_.Exception.Message)" Fail
+        Write-Log "azcmagent check failed: $($_.Exception.Message)" Fail
     }
 }
 else {
-    Write-Log 'azcmagent.exe nao encontrado - pulando check.' Warn
+    Write-Log 'azcmagent.exe not found - skipping check.' Warn
 }
 
 # ---------------------------------------------------------------------------
-# Resumo
+# Summary
 # ---------------------------------------------------------------------------
 [void]$script:LogBuffer.Add('=' * 60)
-Write-Log ("Resumo: OK={0}  Fail={1}  Warn={2}  Modo={3}  Regiao={4}" -f `
+Write-Log ("Summary: OK={0}  Fail={1}  Warn={2}  Mode={3}  Region={4}" -f `
         $script:Stats.OK, $script:Stats.Fail, $script:Stats.Warn, $Mode, $Region) Info -NoCount
 Write-Log "Script finished at $(Get-Date -Format o)" Info -NoCount
 Save-LogBuffer
 
 # ---------------------------------------------------------------------------
-# Tabela de resultados (console + log)
+# Results table (console + log)
 # ---------------------------------------------------------------------------
 $tableObjects = $script:Results | ForEach-Object { [pscustomobject]$_ }
 
 Write-Host ''
-Write-Host '=================== SUMARIO ===================' -ForegroundColor Cyan
+Write-Host '=================== SUMMARY ===================' -ForegroundColor Cyan
 
 $rowFormat = "{0,-5} {1,-55} {2,-26} {3,-8} {4,-5} {5,-5} {6,-12} {7,-9}"
 Write-Host ($rowFormat -f 'Group', 'Endpoint', 'IP', 'Type', 'DNS', 'TCP', 'HTTP', 'Latency') -ForegroundColor Cyan
@@ -918,29 +918,29 @@ foreach ($r in $tableObjects) {
 }
 
 Write-Host ''
-Write-Host ("Totais: OK={0}  Fail={1}  Warn={2}  Modo={3}  Regiao={4}" -f `
+Write-Host ("Totals: OK={0}  Fail={1}  Warn={2}  Mode={3}  Region={4}" -f `
         $script:Stats.OK, $script:Stats.Fail, $script:Stats.Warn, $Mode, $Region) -ForegroundColor Cyan
 
 if ($script:EffectiveProxy) {
-    Write-Host "Proxy utilizado: $($script:EffectiveProxy)" -ForegroundColor DarkGray
+    Write-Host "Proxy used: $($script:EffectiveProxy)" -ForegroundColor DarkGray
 }
 else {
-    Write-Host 'Proxy utilizado: Direct (sem proxy)' -ForegroundColor DarkGray
+    Write-Host 'Proxy used: Direct (no proxy)' -ForegroundColor DarkGray
 }
 
-# Append tabela ao arquivo de log
+# Append table to the log file
 $tableString = $tableObjects | Format-Table -AutoSize | Out-String
 Add-Content -Path $LogFilePath -Value ''
-Add-Content -Path $LogFilePath -Value '=================== SUMARIO ==================='
+Add-Content -Path $LogFilePath -Value '=================== SUMMARY ==================='
 Add-Content -Path $LogFilePath -Value $tableString.TrimEnd()
-Add-Content -Path $LogFilePath -Value ("Totais: OK={0}  Fail={1}  Warn={2}  Modo={3}  Regiao={4}" -f `
+Add-Content -Path $LogFilePath -Value ("Totals: OK={0}  Fail={1}  Warn={2}  Mode={3}  Region={4}" -f `
         $script:Stats.OK, $script:Stats.Fail, $script:Stats.Warn, $Mode, $Region)
 if ($script:EffectiveProxy) {
-    Add-Content -Path $LogFilePath -Value "Proxy utilizado: $($script:EffectiveProxy)"
+    Add-Content -Path $LogFilePath -Value "Proxy used: $($script:EffectiveProxy)"
 }
 else {
-    Add-Content -Path $LogFilePath -Value 'Proxy utilizado: Direct (sem proxy)'
+    Add-Content -Path $LogFilePath -Value 'Proxy used: Direct (no proxy)'
 }
 
-Write-Host "`nLog completo: $LogFilePath" -ForegroundColor Cyan
+Write-Host "`nFull log: $LogFilePath" -ForegroundColor Cyan
 exit ([int]($script:Stats.Fail -gt 0))

--- a/script_automation/arc_endpoint_check/_index.md
+++ b/script_automation/arc_endpoint_check/_index.md
@@ -9,7 +9,7 @@ description: >
 
 ## Overview
 
-`ArcEndpointCheck.ps1` validates network connectivity between a Windows machine and the Azure endpoints required by the Azure Connected Machine agent (Azure Arc). It performs DNS resolution, TCP reachability, and HTTPS probe checks for both **public** and **Private Link** deployments, automatically detecting the deployment mode and honoring the agent's proxy configuration.
+`ArcEndpointCheck.ps1` validates network connectivity between a Windows machine and the Azure endpoints required by the Azure Connected Machine agent (Azure Arc). It performs DNS resolution, TCP reachability, and HTTPS probe checks for both **public** and **Private Link** deployments, automatically detecting the deployment mode and honoring the agent's proxy configuration. In **public** mode it also validates the region's dynamic endpoint allowlist retrieved from the Azure guest notification service; that list is auxiliary, so failures there are reported as warnings and never change the exit code.
 
 Use it before or after onboarding a server to Azure Arc to quickly confirm that every required endpoint is reachable and to pinpoint DNS, firewall, or proxy issues.
 

--- a/script_automation/arc_endpoint_check/_index.md
+++ b/script_automation/arc_endpoint_check/_index.md
@@ -4,37 +4,62 @@ title: "Azure Arc Connectivity Check"
 linkTitle: "Azure Arc Connectivity Check"
 weight: 1
 description: >
+    Validate Azure Connected Machine agent connectivity and endpoints for public or Private Link deployments, with automatic mode detection and proxy awareness.
 ---
 
-## Overview  
+## Overview
 
-This script was created to help identify connectivity issues with the Azure Arc Machine Agent and its endpoints. It tests the necessary URLs, validates Azure Arc functionality, and performs DNS resolution, network connectivity, and HTTP request checks, logging the results for review.
+`ArcEndpointCheck.ps1` validates network connectivity between a Windows machine and the Azure endpoints required by the Azure Connected Machine agent (Azure Arc). It performs DNS resolution, TCP reachability, and HTTPS probe checks for both **public** and **Private Link** deployments, automatically detecting the deployment mode and honoring the agent's proxy configuration.
+
+Use it before or after onboarding a server to Azure Arc to quickly confirm that every required endpoint is reachable and to pinpoint DNS, firewall, or proxy issues.
 
 ## Prerequisites
 
-- PowerShell
-- Network connectivity 
+- Windows Server 2012 R2 or later (Windows PowerShell 5.1 or PowerShell 7+).
+- Run the script from the machine you are validating (locally).
+- Outbound access to the Azure Arc endpoints (directly, or through a proxy / Private Link).
+- Optional: the Azure Connected Machine agent (`azcmagent`) installed, so the script can read the configured proxy URL, bypass list, and run `azcmagent check`.
 
-## Getting Started
+## Getting started
 
-Download the [ArcEndpointCheck.ps1](./ArcEndpointCheck.ps1) and follow these steps to set up and use the script:
+Download `ArcEndpointCheck.ps1` and run it from an elevated PowerShell session on the target machine.
 
-1. **Define the Region**  
-   Set the region for your Azure Arc deployment. For example:  
-   `$region = "brazilsouth"`
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `-Region` | Azure region used to build region-specific endpoints. | `eastus2` |
+| `-Mode` | Deployment mode to validate: `Auto`, `Public`, or `Private`. `Auto` detects Private Link from DNS. | `Auto` |
+| `-ProxyUrl` | Explicit proxy URL. Overrides the agent's `proxy.url` and `HTTPS_PROXY`. | (auto-detected) |
+| `-LogFilePath` | Path of the transcript/log file. | `C:\temp\Arclogfile.txt` |
+| `-IncludeSQL` | Also validate Azure Arc-enabled SQL Server endpoints. | off |
+| `-IncludeAMA` | Also validate Azure Monitor Agent endpoints. | off |
+| `-IncludeMDE` | Also validate Microsoft Defender for Endpoint endpoints. | off |
+| `-IncludeWAC` | Also validate Windows Admin Center in Azure endpoints. | off |
+| `-CheckIncludeAll` | Validate every optional endpoint group and run the broadest `azcmagent check`. | off |
 
-2. **Define the Log File Path**  
-   Specify the location where the log file will be saved. For example:  
-   `$logFilePath = "C:\temp\Arclogfile.txt"`
+## Using the script
 
-3. **Choose Public or Private Deployment**  
-   Determine whether your Azure Arc instance will be public or private.  
-   If you're using a public deployment, make sure to remove the `--enable-pls-check` parameter from the script.
+Run a full automatic check (detects Public vs Private Link):
 
-## Using the Script
+```powershell
+.\ArcEndpointCheck.ps1
+```
 
-Execute the script on the server where the Azure Arc Agent will be installed. When running the script, keep in mind environmental factors such as firewall settings, proxy configuration, region, and whether the connection is public or private. Make the necessary adjustments in the script to account for these aspects. The script includes a check with `AzcmAgent.exe`, so ensure that the Azure Arc Agent is already installed on the server before running it.
+Validate a specific region and force Private Link mode:
 
-## Contributions
+```powershell
+.\ArcEndpointCheck.ps1 -Region westeurope -Mode Private
+```
 
-Contributions are welcome! Feel free to open an _issue_ or submit a _pull request_ to improve this repository.
+Include the Azure Arc-enabled SQL Server endpoints:
+
+```powershell
+.\ArcEndpointCheck.ps1 -IncludeSQL
+```
+
+Validate through an explicit proxy and check every optional endpoint group:
+
+```powershell
+.\ArcEndpointCheck.ps1 -ProxyUrl "http://10.0.1.4:8443" -CheckIncludeAll
+```
+
+The script writes a color-coded summary to the console and a transcript to the log file. It exits with code `0` when all required checks pass and `1` when any check fails, so it can be used in automation and onboarding pipelines.

--- a/script_automation/arc_endpoint_check/_index.md
+++ b/script_automation/arc_endpoint_check/_index.md
@@ -4,62 +4,266 @@ title: "Azure Arc Connectivity Check"
 linkTitle: "Azure Arc Connectivity Check"
 weight: 1
 description: >
-    Validate Azure Connected Machine agent connectivity and endpoints for public or Private Link deployments, with automatic mode detection and proxy awareness.
+    Validate Azure Arc agent connectivity, TLS configuration, proxy bypass, and
+    extension endpoints across Public, Private Link, and Gateway deployments —
+    with full auto-detection and pre-onboarding support.
 ---
 
 ## Overview
 
-`ArcEndpointCheck.ps1` validates network connectivity between a Windows machine and the Azure endpoints required by the Azure Connected Machine agent (Azure Arc). It performs DNS resolution, TCP reachability, and HTTPS probe checks for both **public** and **Private Link** deployments, automatically detecting the deployment mode and honoring the agent's proxy configuration. In **public** mode it also validates the region's dynamic endpoint allowlist retrieved from the Azure guest notification service; that list is auxiliary, so failures there are reported as warnings and never change the exit code.
+This script validates network connectivity for Azure Arc-enabled servers across all
+three connectivity modes: **Public**, **Private Link**, and **Gateway**. It auto-detects
+region, connectivity mode, proxy configuration, installed extensions, and regional
+endpoints — run it with **zero parameters** on any machine where the agent is installed.
 
-Use it before or after onboarding a server to Azure Arc to quickly confirm that every required endpoint is reachable and to pinpoint DNS, firewall, or proxy issues.
+For **pre-onboarding** (agent not yet installed), pass `-Region`, `-Mode`, and
+`-CheckIncludeAll` to validate the network before deploying.
+
+### What it validates
+
+| Area | Details |
+| ---- | ------- |
+| **Core endpoints** | AAD, ARM, HIMDS, GuestConfig, GNS, packages, downloads |
+| **Regional endpoints** | Discovered via `azcmagent check` or DNS-based abbreviation map (40+ regions) |
+| **Extension endpoints** | SQL, AMA, MDE, WAC, Key Vault, Hybrid Worker, Change Tracking, Update Manager, Guest Attestation, Dependency Agent, Defender for SQL — auto-detected from installed extensions |
+| **DNS + TCP/443** | Resolution, private vs public IP classification, latency measurement |
+| **HTTP probes** | Layer-7 reachability through proxy for key endpoints |
+| **TLS 1.2/1.3** | SCHANNEL registry, live handshake test, cipher suite validation (GCM), .NET StrongCrypto |
+| **PKI/OCSP/CRL bypass** | Detects missing proxy bypass for certificate validation endpoints (Azure Firewall explicit proxy "non-proxy request on proxy port" scenario) |
+| **Proxy configuration** | WinHTTP, `azcmagent proxy.url`, `HTTPS_PROXY`, `proxy.bypass` categories, upstream proxy (Gateway) |
+| **Dynamic GNS allowlist** | Queries `guestnotificationservice.azure.com` for region-specific ServiceBus endpoints (Public mode) |
+| **Arc Gateway** | Validates gateway URL, detects `proxy.bypass` misconfiguration in Gateway mode |
+
+### Key improvements over earlier versions
+
+- **Zero parameters needed** — auto-detects everything from `azcmagent show -j`,
+  `azcmagent check`, `azcmagent extension list`, WinHTTP, and environment variables.
+- **Three connectivity modes** — Public, Private Link, and Gateway (with gateway URL
+  validation and upstream proxy display).
+- **Pre-onboarding mode** — works without `azcmagent` installed; uses DNS-based regional
+  endpoint discovery with a built-in abbreviation map for 40+ Azure regions.
+- **PKI bypass validation** — detects when WinHTTP proxy is configured but PKI/OCSP/CRL
+  endpoints are missing from the bypass list (root cause of Azure Firewall explicit proxy
+  TLS failures).
+- **TLS validation** — SCHANNEL registry check, live TLS 1.2 handshake, cipher suite
+  verification, .NET StrongCrypto, and Server 2012 (non-R2) SQL Arc incompatibility
+  warning.
+- **Extension auto-detection** — discovers 12 extension types from `azcmagent extension list`
+  and tests their specific endpoints.
+- **Pipe-delimited output** — `azcmagent check` style tabular format with consolidated
+  `Result` column (Reachable / FAIL(DNS,TCP) / Warning).
+- **Smart exit codes** — `0` = PASS or WARN-only, `1` = FAIL (CRITICAL/HIGH issues).
+  WARN-level issues (e.g., Gateway bypass, Discovery) do not cause exit 1.
+- **Locale-independent** WinHTTP proxy detection with URL-based fallback for non-EN/PT
+  systems.
 
 ## Prerequisites
 
-- Windows Server 2012 R2 or later (Windows PowerShell 5.1 or PowerShell 7+).
-- Run the script from the machine you are validating (locally).
-- Outbound access to the Azure Arc endpoints (directly, or through a proxy / Private Link).
-- Optional: the Azure Connected Machine agent (`azcmagent`) installed, so the script can read the configured proxy URL, bypass list, and run `azcmagent check`.
+- **Windows PowerShell 5.1 or later** (the script uses `netsh`, `Resolve-DnsName`, and
+  `azcmagent.exe`).
+- Outbound network connectivity to Azure Arc endpoints (directly, via proxy, or via
+  Gateway).
+- *(Optional)* The **Azure Connected Machine agent** (`azcmagent.exe`). Without it the
+  script runs in pre-onboarding mode — DNS/TCP/HTTP/TLS tests still execute, but
+  `azcmagent check` and extension auto-detection are skipped.
+- Run from an **elevated PowerShell** session for the most complete results.
 
-## Getting started
+## Getting Started
 
-Download `ArcEndpointCheck.ps1` and run it from an elevated PowerShell session on the target machine.
+Download [arcendpointcheck.ps1](./arcendpointcheck.ps1) and run it on the server where
+the Azure Arc agent is (or will be) installed.
+
+**You never edit the script.** Everything is controlled by parameters:
 
 | Parameter | Description | Default |
-| --- | --- | --- |
-| `-Region` | Azure region used to build region-specific endpoints. | `eastus2` |
-| `-Mode` | Deployment mode to validate: `Auto`, `Public`, or `Private`. `Auto` detects Private Link from DNS. | `Auto` |
-| `-ProxyUrl` | Explicit proxy URL. Overrides the agent's `proxy.url` and `HTTPS_PROXY`. | (auto-detected) |
-| `-LogFilePath` | Path of the transcript/log file. | `C:\temp\Arclogfile.txt` |
-| `-IncludeSQL` | Also validate Azure Arc-enabled SQL Server endpoints. | off |
-| `-IncludeAMA` | Also validate Azure Monitor Agent endpoints. | off |
-| `-IncludeMDE` | Also validate Microsoft Defender for Endpoint endpoints. | off |
-| `-IncludeWAC` | Also validate Windows Admin Center in Azure endpoints. | off |
-| `-CheckIncludeAll` | Validate every optional endpoint group and run the broadest `azcmagent check`. | off |
+| --------- | ----------- | ------- |
+| `-Region` | Azure region (e.g., `eastus2`, `brazilsouth`). Auto-detected from `azcmagent show` if omitted. | *(auto-detect or `eastus2`)* |
+| `-Mode` | `Auto`, `Public`, `Private`, or `Gateway`. In `Auto`, the script checks `azcmagent show` for Private Link Scope or Gateway URL, then falls back to a DNS heuristic (`gbl.his.arc.azure.com` → private IP = Private). `Private` automatically adds `--enable-pls-check` to `azcmagent check`. | `Auto` |
+| `-ProxyUrl` | Explicit HTTP/HTTPS proxy (e.g., `http://10.0.1.4:8443`). If omitted, auto-detects in order: `azcmagent proxy.url` → `HTTPS_PROXY` env var → WinHTTP (pre-onboarding only). | *(auto-detect)* |
+| `-LogFilePath` | Path to the log file. Includes hostname automatically. | `C:\temp\ArcEndpointCheck_<HOSTNAME>.txt` |
+| `-SkipPKI` | Skips PKI/OCSP/CRL bypass validation and endpoint testing (not recommended). | *(off)* |
+| `-SkipExtensions` | Skips all extension endpoint testing. Overrides `-CheckIncludeAll`. | *(off)* |
+| `-CheckIncludeAll` | Tests ALL extension endpoints (even without agent detection). Also makes `azcmagent check` use `--extensions all --include-all`. Ideal for pre-onboarding validation. | *(off)* |
 
-## Using the script
+## Using the Script
 
-Run a full automatic check (detects Public vs Private Link):
+### Post-onboarding (agent installed)
 
 ```powershell
-.\ArcEndpointCheck.ps1
+# Full auto — zero parameters needed
+.\arcendpointcheck.ps1
+
+# Force a specific region
+.\arcendpointcheck.ps1 -Region brazilsouth
+
+# Force Private Link mode with verbose logging
+.\arcendpointcheck.ps1 -Mode Private -Verbose
+
+# Test all extension endpoints (including not yet installed)
+.\arcendpointcheck.ps1 -CheckIncludeAll
 ```
 
-Validate a specific region and force Private Link mode:
+### Pre-onboarding (agent not installed)
 
 ```powershell
-.\ArcEndpointCheck.ps1 -Region westeurope -Mode Private
+# Minimum: region + test all extensions
+.\arcendpointcheck.ps1 -Region eastus2 -CheckIncludeAll
+
+# Full pre-onboarding with proxy + Private Link
+.\arcendpointcheck.ps1 -Region eastus2 -Mode Private -ProxyUrl http://10.0.1.4:8443 -CheckIncludeAll
+
+# Public mode, specific region, skip PKI (firewall team will handle)
+.\arcendpointcheck.ps1 -Region brazilsouth -Mode Public -SkipPKI -CheckIncludeAll
 ```
 
-Include the Azure Arc-enabled SQL Server endpoints:
+### Azure Firewall explicit proxy scenarios
 
 ```powershell
-.\ArcEndpointCheck.ps1 -IncludeSQL
+# Validate connectivity through explicit proxy (auto-detected from azcmagent/WinHTTP)
+.\arcendpointcheck.ps1
+
+# Override proxy URL if not yet configured in azcmagent
+.\arcendpointcheck.ps1 -ProxyUrl http://10.0.1.4:8443
 ```
 
-Validate through an explicit proxy and check every optional endpoint group:
+## Output Format
 
-```powershell
-.\ArcEndpointCheck.ps1 -ProxyUrl "http://10.0.1.4:8443" -CheckIncludeAll
+The script produces pipe-delimited tables matching the `azcmagent check` style:
+
+### Header
+
+```
+==========================================================================
+  AZURE ARC ENDPOINT CHECK
+==========================================================================
+  Host:                  SQLNODE1
+  Time:                  2026-07-03 17:38:51
+  Agent:                 Installed | Connected | v1.65.03439.3010
+  Region:                eastus2 (auto-detected)
+  Mode:                  Private
+  Extensions:            SQL, AMA, MDE, WAC, CT, UM, DSQL
 ```
 
-The script writes a color-coded summary to the console and a transcript to the log file. It exits with code `0` when all required checks pass and `1` when any check fails, so it can be used in automation and onboarding pipelines.
+### Proxy Configuration
+
+```
+  Source             | Proxy                               | Used By
+  -------------------+-------------------------------------+-----------------------
+  WinHTTP (OS)       | http://10.0.1.4:8443                | SCHANNEL/OCSP/CRL
+  azcmagent          | http://10.0.1.4:8443                | Arc Agent
+  HTTPS_PROXY        | http://10.0.1.4:8443                | Extensions
+```
+
+### Results Table
+
+```
+  Group | Endpoint                                           | IP               | Type | Result    | Latency
+  ------+----------------------------------------------------+------------------+------+-----------+--------
+  Core  | login.windows.net                                  | 20.190.173.132   | PUB  | Reachable | 24ms
+  Core  | gbl.his.arc.azure.com                              | 10.1.0.4         | PRIV | Reachable | 305ms
+  PKI   | oneocsp.microsoft.com                              | 204.79.197.203   | PUB  | Reachable | 33ms
+  SQL   | dataprocessingservice.eastus2.arcdataservices.com   | 72.153.30.41     | PUB  | Reachable | 130ms
+```
+
+**Result values:**
+
+| Result | Meaning |
+| ------ | ------- |
+| `Reachable` | DNS + TCP + HTTP all passed |
+| `Reachable*` | DNS + TCP passed, HTTP skipped (proxy.bypass active) |
+| `FAIL(DNS)` | DNS resolution failed |
+| `FAIL(TCP)` | TCP/443 connection timed out |
+| `FAIL(DNS,TCP)` | Both DNS and TCP failed |
+| `FAIL(HTTP)` | HTTP probe failed (proxy/firewall blocking) |
+| `Warning` | Mode mismatch (e.g., Private mode but endpoint resolves to public IP) |
+
+### Issues Table
+
+```
+  #   | Severity | Category     | Message
+  ----+----------+--------------+---------------------------------------------------
+  1   | CRITICAL | PKI Bypass   | 2 PKI endpoint(s) not in proxy bypass
+      |          |              | Fix: Add to GPO NO_PROXY: crl4.digicert.com
+```
+
+### Summary Line
+
+```
+  STATUS: PASS  |  OK:74 Fail:0 Warn:0 Issues:0  |  Private eastus2
+```
+
+Tags appended when applicable: `[GW]` for Gateway mode, `[PRE-ONBOARDING]` when agent
+is not installed.
+
+## Exit Codes
+
+| Code | Status | Meaning |
+| ---- | ------ | ------- |
+| `0` | PASS | All checks passed |
+| `0` | WARN | Only WARN/MEDIUM severity issues (e.g., Gateway bypass, Discovery) |
+| `1` | FAIL | At least one CRITICAL or HIGH severity issue, or a DNS/TCP test failure |
+
+## Auto-Detection Logic
+
+The script automatically detects the following without any parameters:
+
+| What | Source | Fallback |
+| ---- | ------ | -------- |
+| **Region** | `azcmagent show -j` → `.location` | Default `eastus2` (with warning) |
+| **Mode** | `azcmagent show -j` → `.privateLinkScope` / `.gatewayUrl` / `.connectionType` | DNS heuristic: `gbl.his.arc.azure.com` → private IP = Private |
+| **Proxy** | `azcmagent config get proxy.url` → `HTTPS_PROXY` env → WinHTTP (pre-onboarding) | None (direct) |
+| **Extensions** | `azcmagent extension list` (12 types: SQL, AMA, MDE, WAC, KV, HRW, CT, GA, UM, CS, DA, DSQL) | `-CheckIncludeAll` tests all |
+| **Regional endpoints** | `azcmagent check` output parsing | DNS probe with abbreviation map (40+ regions) |
+| **Gateway URL** | `azcmagent show -j` → `.gatewayUrl` | Manual `-Mode Gateway` |
+| **Agent status** | `azcmagent show -j` → `.status` / `.agentVersion` | N/A |
+
+## PKI/OCSP/CRL Bypass Validation
+
+When a WinHTTP proxy is detected, the script validates that all PKI endpoints are in
+the proxy bypass list (WinHTTP bypass or `NO_PROXY` environment variable). This is
+critical for **Azure Firewall explicit proxy** deployments, where Windows SCHANNEL
+sends OCSP/CRL requests through WinHTTP — if these endpoints are not bypassed, the
+firewall rejects them with *"Received a non-proxy request on a proxy port"*.
+
+**PKI endpoints validated:**
+
+| Endpoint | Purpose |
+| -------- | ------- |
+| `oneocsp.microsoft.com` | OCSP primary |
+| `crl.microsoft.com` | CRL Microsoft root |
+| `crl2.microsoft.com` | CRL Microsoft intermediate |
+| `crl3.digicert.com` | CRL DigiCert |
+| `crl4.digicert.com` | CRL DigiCert alt |
+| `ocsp.digicert.com` | OCSP DigiCert |
+| `ctldl.windowsupdate.com` | Certificate Trust List |
+| `www.microsoft.com` | PKI AIA chain |
+| `caissuers.microsoft.com` | CA Issuers (AIA) |
+| `login.live.com` | Live ID cert validation |
+
+The script normalizes both WinHTTP wildcard format (`*.domain.com`) and `NO_PROXY`
+format (`.domain.com`) for accurate bypass matching.
+
+## TLS Validation
+
+Azure Arc requires **TLS 1.2 or 1.3**. The script performs a multi-layer check:
+
+1. **SCHANNEL registry** — verifies TLS 1.2 Client is not disabled via
+   `DisabledByDefault` or `Enabled=0`.
+2. **Live handshake** — attempts a real TLS 1.2 connection to
+   `login.microsoftonline.com` (through proxy if configured).
+3. **Cipher suites** — verifies required GCM ciphers are present:
+   - TLS 1.2: `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`,
+     `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
+   - TLS 1.3: `TLS_AES_256_GCM_SHA384`, `TLS_AES_128_GCM_SHA256`
+4. **.NET StrongCrypto** — checks `SchUseStrongCrypto` registry (recommended for
+   PS 5.1).
+5. **Server 2012 (non-R2)** — warns that SQL Arc (`*.arcdataservices.com`) is not
+   supported.
+
+## References
+
+- [Azure Arc network requirements (consolidated)](https://learn.microsoft.com/azure/azure-arc/network-requirements-consolidated)
+- [Azure Arc Gateway](https://learn.microsoft.com/azure/azure-arc/servers/arc-gateway)
+- [Azure Firewall explicit proxy with Arc](https://learn.microsoft.com/azure/azure-arc/azure-firewall-explicit-proxy)
+- [Troubleshoot Windows TLS configuration](https://learn.microsoft.com/azure/azure-arc/servers/troubleshoot-networking#windows-tls-configuration-issues)
+- [Private Link for Azure Arc](https://learn.microsoft.com/azure/azure-arc/servers/private-link-security)


### PR DESCRIPTION
## Description

This PR updates the **Azure Arc Connectivity Check** drop (`script_automation/arc_endpoint_check`) with a hardened, docs-aligned version of `ArcEndpointCheck.ps1` (v2.6.0) and a refreshed `_index.md`.

### What's changed

- **Endpoint alignment** with the official Connected Machine agent network requirements (core vs. optional groups: SQL, AMA, MDE, WAC).
- **Automatic mode detection** (Public vs. Azure Private Link) via `azcmagent show -j` and DNS/RFC1918 heuristic.
- **Proxy awareness** mirroring the agent precedence (`-ProxyUrl` > `azcmagent proxy.url` > `HTTPS_PROXY`); the Windows system-wide proxy is only reported, never applied, matching the agent. Honors `azcmagent proxy.bypass` categories to skip HTTP probes that the agent would not send through the proxy.
- **IPv4 (A record) preference** to avoid misclassifying Private Link endpoints that also expose a public AAAA record.
- **Resilient GNS handling**: dynamic allowlist (guestnotificationservice) failures are treated as WARN (not FAIL) so a transient SERVFAIL doesn't fail the run; DNS gets one retry.
- **AMA metrics endpoint** (`global.prod.microsoftmetrics.com`) added.
- Runs `azcmagent check` with the correct flags per mode (`--enable-pls-check` for Private; `--extensions all --include-all` with `-CheckIncludeAll`).
- Exit code `0` when all checks pass, `1` on any failure — usable in onboarding pipelines.

### Files

- `script_automation/arc_endpoint_check/ArcEndpointCheck.ps1`
- `script_automation/arc_endpoint_check/_index.md`

Validated on a real Windows Server (Azure Arc-enabled, Private Link + Explicit Proxy) across all parameter combinations.
